### PR TITLE
FIX for GPU resource data is not present on MI300A

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-  * @dgaliffiAMD @ajanicijamd @wilephan-amd @jrmadsen 
+* @dgaliffiAMD @ajanicijamd @wilephan-amd @jrmadsen 
 
 # Documentation files
 docs/* @ROCm/rocm-documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @jrmadsen @dgaliffiAMD
+  * @dgaliffiAMD @ajanicijamd @wilephan-amd @jrmadsen 
 
 # Documentation files
 docs/* @ROCm/rocm-documentation


### PR DESCRIPTION
This pull request addresses an issue where GPU resource data, such as power and temperature, was missing from traces on MI300A. The data is typically tracked through ROCm-SMI.

### Changes Made

1. **Temperature Metric:**
   - Changed the temperature metric from `RSMI_TEMP_TYPE_EDGE` to 

RSMI_TEMP_TYPE_JUNCTION

as per https://rocm.docs.amd.com/projects/rocm_smi_lib/en/latest/doxygen/html/group__PhysQuer.html#ga40e9da04e4c0cfa17a4f38b97ebc9669

 to ensure accurate temperature readings for MI300A as the type RSMI_TEMP_TYPE_EDGE failed to return valid measurement on MI300A.
   ```cpp
   ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).temp, rsmi_dev_temp_metric_get, _dev_id,
                       RSMI_TEMP_TYPE_JUNCTION, RSMI_TEMP_CURRENT, &m_temp);
   ```

2. **Power Metric:**
   - Updated the power metric retrieval method from `rsmi_dev_power_ave_get` to 

rsmi_dev_power_get

 and specified the power type as 

RSMI_CURRENT_POWER

as per https://rocm.docs.amd.com/projects/rocm_smi_lib/en/latest/doxygen/html/group__PowerQuer.html#ga5c6fcd74be46ae056526c96d1a3ac09b

 to ensure accurate power readings for MI300A.
   ```cpp
   RSMI_POWER_TYPE power_type = RSMI_CURRENT_POWER;                    
   ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).power, rsmi_dev_power_get, _dev_id, &m_power, 
                       &power_type);
   ```

### Reason for Changes

These changes were made to ensure that GPU resource data, such as power and temperature, is accurately tracked and included in traces for MI300A. The previous code was not providing power and temperature traces on MI300A.

### Testing

- Verified that the updated metrics provide accurate and complete data for MI300A & MI300X.
- Ensured that the changes do not affect the functionality for other GPU models.