### PR TITLE
Fix GPU resource data of GPU power and temperature is not present on …

### DIFF
--- a/source/lib/rocprof-sys/library/rocm_smi.cpp
+++ b/source/lib/rocprof-sys/library/rocm_smi.cpp
@@ -154,8 +154,8 @@ data::sample(uint32_t _dev_id)
                         &m_busy_perc);
     ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).temp, rsmi_dev_temp_metric_get, _dev_id,
                         RSMI_TEMP_TYPE_JUNCTION, RSMI_TEMP_CURRENT, &m_temp);
-    RSMI_POWER_TYPE power_type = RSMI_CURRENT_POWER;                    
-    ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).power, rsmi_dev_power_get, _dev_id, &m_power, 
+    RSMI_POWER_TYPE power_type = RSMI_CURRENT_POWER;
+    ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).power, rsmi_dev_power_get, _dev_id, &m_power,
                         &power_type)
     ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).mem_usage, rsmi_dev_memory_usage_get,
                         _dev_id, RSMI_MEM_TYPE_VRAM, &m_mem_usage);

--- a/source/lib/rocprof-sys/library/rocm_smi.cpp
+++ b/source/lib/rocprof-sys/library/rocm_smi.cpp
@@ -153,9 +153,10 @@ data::sample(uint32_t _dev_id)
     ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).busy, rsmi_dev_busy_percent_get, _dev_id,
                         &m_busy_perc);
     ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).temp, rsmi_dev_temp_metric_get, _dev_id,
-                        RSMI_TEMP_TYPE_EDGE, RSMI_TEMP_CURRENT, &m_temp);
-    ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).power, rsmi_dev_power_ave_get, _dev_id, 0,
-                        &m_power);
+                        RSMI_TEMP_TYPE_JUNCTION, RSMI_TEMP_CURRENT, &m_temp);
+    RSMI_POWER_TYPE power_type = RSMI_CURRENT_POWER;                    
+    ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).power, rsmi_dev_power_get, _dev_id, &m_power, 
+                        &power_type)
     ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).mem_usage, rsmi_dev_memory_usage_get,
                         _dev_id, RSMI_MEM_TYPE_VRAM, &m_mem_usage);
 

--- a/source/lib/rocprof-sys/library/rocm_smi.cpp
+++ b/source/lib/rocprof-sys/library/rocm_smi.cpp
@@ -155,8 +155,8 @@ data::sample(uint32_t _dev_id)
     ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).temp, rsmi_dev_temp_metric_get, _dev_id,
                         RSMI_TEMP_TYPE_JUNCTION, RSMI_TEMP_CURRENT, &m_temp);
     RSMI_POWER_TYPE power_type = RSMI_CURRENT_POWER;
-    ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).power, rsmi_dev_power_get, _dev_id, &m_power,
-                        &power_type)
+    ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).power, rsmi_dev_power_get, _dev_id,
+                        &m_power, &power_type)
     ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).mem_usage, rsmi_dev_memory_usage_get,
                         _dev_id, RSMI_MEM_TYPE_VRAM, &m_mem_usage);
 


### PR DESCRIPTION
This pull request addresses an issue where GPU resource data, such as power and temperature, was missing from traces on MI300A. The data is typically tracked through ROCm-SMI.

Changes Made
Temperature Metric:
Changed the temperature metric from RSMI_TEMP_TYPE_EDGE to
RSMI_TEMP_TYPE_JUNCTION

to ensure accurate temperature readings for MI300A.

ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).temp, rsmi_dev_temp_metric_get, _dev_id,
                    RSMI_TEMP_TYPE_JUNCTION, RSMI_TEMP_CURRENT, &m_temp);
Power Metric:
Updated the power metric retrieval method from rsmi_dev_power_ave_get to
rsmi_dev_power_get

and specified the power type as

RSMI_CURRENT_POWER

to ensure accurate power readings for MI300A.

RSMI_POWER_TYPE power_type = RSMI_CURRENT_POWER;                    
ROCPROFSYS_RSMI_GET(get_settings(m_dev_id).power, rsmi_dev_power_get, _dev_id, &m_power, 
                    &power_type);
Reason for Changes
These changes were made to ensure that GPU resource data, such as power and temperature, is accurately tracked and included in traces for MI300A. The previous metrics were not providing the necessary data for this specific GPU model.

Testing
Verified that the updated metrics provide accurate and complete data for MI300A.
Ensured that the changes do not affect the functionality for other GPU models.