### PR TITLE
Allow disabling of openmp examples

### DIFF
--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -67,7 +67,7 @@ if(ROCPROFSYS_INSTALL_EXAMPLES)
 endif()
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
-    if(NOT "rocprofiler-systems-openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+    if(NOT "openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
         add_subdirectory(target)
     endif()
 else()

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -2,6 +2,15 @@ cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(rocprofiler-systems-openmp LANGUAGES CXX)
 
+if(ROCPROFSYS_DISABLE_EXAMPLES)
+    get_filename_component(_DIR ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+    if(${PROJECT_NAME} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES OR ${_DIR} IN_LIST
+                                                              ROCPROFSYS_DISABLE_EXAMPLES)
+        return()
+    endif()
+endif()
+
 file(GLOB common_source ${CMAKE_CURRENT_SOURCE_DIR}/common/*.cpp)
 add_library(openmp-common OBJECT ${common_source})
 target_include_directories(openmp-common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common)
@@ -57,6 +66,12 @@ if(ROCPROFSYS_INSTALL_EXAMPLES)
         COMPONENT rocprofiler-systems-examples)
 endif()
 
-if(NOT DEFINED ROCPROFSYS_BUILD_OPENMP_TARGET OR ROCPROFSYS_BUILD_OPENMP_TARGET)
+if(ROCPROFSYS_DISABLE_EXAMPLES)
+    get_filename_component(_DIR ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+    if(NOT "rocprofiler-systems-openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        add_subdirectory(target)
+    endif()
+else()
     add_subdirectory(target)
 endif()

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -67,9 +67,7 @@ if(ROCPROFSYS_INSTALL_EXAMPLES)
 endif()
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
-    get_filename_component(_DIR ${CMAKE_CURRENT_LIST_DIR} NAME)
-
-    if(NOT "rocprofiler-systems-openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+    if(ROCPROFSYS_DISABLE_EXAMPLES AND NOT "rocprofiler-systems-openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
         add_subdirectory(target)
     endif()
 else()

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -57,4 +57,6 @@ if(ROCPROFSYS_INSTALL_EXAMPLES)
         COMPONENT rocprofiler-systems-examples)
 endif()
 
-# add_subdirectory(target)
+if(NOT DEFINED ROCPROFSYS_BUILD_OPENMP_TARGET OR ROCPROFSYS_BUILD_OPENMP_TARGET)
+    add_subdirectory(target)
+endif()

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -57,4 +57,4 @@ if(ROCPROFSYS_INSTALL_EXAMPLES)
         COMPONENT rocprofiler-systems-examples)
 endif()
 
-add_subdirectory(target)
+# add_subdirectory(target)

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -67,7 +67,7 @@ if(ROCPROFSYS_INSTALL_EXAMPLES)
 endif()
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
-    if(ROCPROFSYS_DISABLE_EXAMPLES AND NOT "rocprofiler-systems-openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+    if(NOT "rocprofiler-systems-openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
         add_subdirectory(target)
     endif()
 else()


### PR DESCRIPTION
This PR is aimed at fixing an external CI pipeline failure related to the openmp target example.

This change enables the disabling of the openmp examples as well as specifically the target example.

Passing build: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=16885&view=results