### PR TITLE
Update env var `KOKKOS_PROFILE_LIBRARY` to `KOKKOS_TOOLS_LIBS`

### DIFF
--- a/docs/how-to/sampling-call-stack.rst
+++ b/docs/how-to/sampling-call-stack.rst
@@ -281,7 +281,7 @@ The following snippets show how ``rocprof-sys-sample`` runs with various environ
 
       $ rocprof-sys-sample -PTDH -I all -- ./parallel-overhead-locks 30 4 100
 
-      KOKKOS_PROFILE_LIBRARY=/opt/rocprofiler-systems/lib/librocprof-sys.so.1.7.1
+      KOKKOS_TOOLS_LIBS=/opt/rocprofiler-systems/lib/librocprof-sys.so.1.7.1
       LD_PRELOAD=/opt/rocprofiler-systems/lib/librocprof-sys-dl.so.1.7.1
       ROCPROFSYS_CPU_FREQ_ENABLED=true
       ROCPROFSYS_TRACE_THREAD_LOCKS=true

--- a/source/bin/rocprof-sys-sample/impl.cpp
+++ b/source/bin/rocprof-sys-sample/impl.cpp
@@ -770,7 +770,7 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
                 update_env(_env, "OMP_TOOL_LIBRARIES", _dl_libpath, UPD_APPEND);
 
             if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
-                update_env(_env, "KOKKOS_PROFILE_LIBRARY", _omni_libpath, UPD_APPEND);
+                update_env(_env, "KOKKOS_TOOLS_LIBS", _omni_libpath, UPD_APPEND);
         });
 
     parser.add_argument({ "-E", "--exclude" }, "Exclude data from these backends")
@@ -800,7 +800,7 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
                 remove_env(_env, "OMP_TOOL_LIBRARIES");
 
             if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
-                remove_env(_env, "KOKKOS_PROFILE_LIBRARY");
+                remove_env(_env, "KOKKOS_TOOLS_LIBS");
         });
 
     parser.start_group("HARDWARE COUNTER OPTIONS", "See also: rocprof-sys-avail -H");

--- a/source/lib/core/argparse.cpp
+++ b/source/lib/core/argparse.cpp
@@ -616,7 +616,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                                UPD_PREPEND);
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
-                    update_env(_data, "KOKKOS_PROFILE_LIBRARY", _data.omni_libpath,
+                    update_env(_data, "KOKKOS_TOOLS_LIBS", _data.omni_libpath,
                                UPD_PREPEND);
             });
 
@@ -649,7 +649,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                     remove_env(_data, "OMP_TOOL_LIBRARIES");
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
-                    remove_env(_data, "KOKKOS_PROFILE_LIBRARY");
+                    remove_env(_data, "KOKKOS_TOOLS_LIBS");
             });
 
         _data.processed_environs.emplace("exclude");

--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -1137,7 +1137,7 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
 
     if(_config->get<bool>("ROCPROFSYS_USE_KOKKOSP"))
     {
-        auto _current_kokkosp_lib = tim::get_env<std::string>("KOKKOS_PROFILE_LIBRARY");
+        auto _current_kokkosp_lib = tim::get_env<std::string>("KOKKOS_TOOLS_LIBS");
         if(_current_kokkosp_lib.find("librocprof-sys-dl.so") == std::string::npos &&
            _current_kokkosp_lib.find("librocprof-sys.so") == std::string::npos)
         {
@@ -1149,9 +1149,9 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
                 _message =
                     JOIN("", " (forced. Previous value: '", _current_kokkosp_lib, "')");
             }
-            ROCPROFSYS_BASIC_VERBOSE_F(1, "Setting KOKKOS_PROFILE_LIBRARY=%s%s\n",
+            ROCPROFSYS_BASIC_VERBOSE_F(1, "Setting KOKKOS_TOOLS_LIBS=%s%s\n",
                                        "librocprof-sys.so", _message.c_str());
-            tim::set_env("KOKKOS_PROFILE_LIBRARY", "librocprof-sys.so", _force);
+            tim::set_env("KOKKOS_TOOLS_LIBS", "librocprof-sys.so", _force);
         }
     }
 

--- a/source/lib/rocprof-sys/library/kokkosp.cpp
+++ b/source/lib/rocprof-sys/library/kokkosp.cpp
@@ -216,8 +216,7 @@ extern "C"
            (!rocprofsys::config::settings_are_configured() &&
             rocprofsys::get_state() < rocprofsys::State::Active))
         {
-            auto _kokkos_profile_lib =
-                tim::get_env<std::string>("KOKKOS_PROFILE_LIBRARY");
+            auto _kokkos_profile_lib = tim::get_env<std::string>("KOKKOS_TOOLS_LIBS");
             if(_kokkos_profile_lib.find("librocprof-sys.so") != std::string::npos)
             {
                 auto _maps = tim::procfs::read_maps(tim::process::get_id());
@@ -238,10 +237,10 @@ extern "C"
                             _libs_str << "    " << litr << "\n";
                         ROCPROFSYS_ABORT(
                             "%s was invoked with librocprof-sys.so as the "
-                            "KOKKOS_PROFILE_LIBRARY.\n"
+                            "KOKKOS_TOOLS_LIBS.\n"
                             "However, librocprof-sys-dl.so has already been loaded by "
                             "the process.\nTo avoid duplicate collections culminating "
-                            "is an error, please set KOKKOS_PROFILE_LIBRARY=%s.\nLoaded "
+                            "is an error, please set KOKKOS_TOOLS_LIBS=%s.\nLoaded "
                             "libraries:\n%s",
                             __FUNCTION__, itr.c_str(), _libs_str.str().c_str());
                     }

--- a/tests/rocprof-sys-kokkos-tests.cmake
+++ b/tests/rocprof-sys-kokkos-tests.cmake
@@ -26,7 +26,7 @@ rocprofiler_systems_add_test(
     LABELS "kokkos;kokkos-profile-library"
     RUN_ARGS -i 25 -s 20 -p
     ENVIRONMENT
-        "${_base_environment};ROCPROFSYS_USE_KOKKOSP=ON;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_KOKKOSP_PREFIX=[kokkos];KOKKOS_PROFILE_LIBRARY=librocprof-sys-dl.so"
+        "${_base_environment};ROCPROFSYS_USE_KOKKOSP=ON;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_KOKKOSP_PREFIX=[kokkos];KOKKOS_TOOLS_LIBS=librocprof-sys-dl.so"
     REWRITE_RUN_PASS_REGEX "\\|_\\[kokkos\\] [a-zA-Z]"
     RUNTIME_PASS_REGEX "\\|_\\[kokkos\\] [a-zA-Z]")
 
@@ -40,7 +40,7 @@ rocprofiler_systems_add_test(
     LABELS "kokkos;kokkos-profile-library"
     RUN_ARGS -i 10 -s 20 -p
     ENVIRONMENT
-        "${_base_environment};ROCPROFSYS_USE_KOKKOSP=ON;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_KOKKOSP_PREFIX=[kokkos];KOKKOS_PROFILE_LIBRARY=librocprof-sys.so"
+        "${_base_environment};ROCPROFSYS_USE_KOKKOSP=ON;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_KOKKOSP_PREFIX=[kokkos];KOKKOS_TOOLS_LIBS=librocprof-sys.so"
     BASELINE_PASS_REGEX "\\|_\\[kokkos\\] [a-zA-Z]")
 
 rocprofiler_systems_add_test(
@@ -53,7 +53,7 @@ rocprofiler_systems_add_test(
     LABELS "kokkos;kokkos-profile-library"
     RUN_ARGS -i 10 -s 20 -p
     ENVIRONMENT
-        "${_base_environment};ROCPROFSYS_USE_KOKKOSP=ON;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_KOKKOSP_PREFIX=[kokkos];KOKKOS_PROFILE_LIBRARY=librocprof-sys-dl.so"
+        "${_base_environment};ROCPROFSYS_USE_KOKKOSP=ON;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_KOKKOSP_PREFIX=[kokkos];KOKKOS_TOOLS_LIBS=librocprof-sys-dl.so"
     BASELINE_PASS_REGEX "\\|_\\[kokkos\\] [a-zA-Z]")
 
 rocprofiler_systems_add_test(


### PR DESCRIPTION
This PR updates the name of the environment variable name `KOKKOS_PROFILE_LIBRARY` to `KOKKOS_TOOLS_LIBS `.

This environment variable name `KOKKOS_PROFILE_LIBRARY` is deprecated in Kokkos:
- https://github.com/kokkos/kokkos//commit/815551b60bb26ef4a1f101705d89c7ca2f91eb2c