### PR TITLE
Add the `--no-defaults` arg for the causal tests

### DIFF
--- a/source/bin/rocprof-sys-causal/impl.cpp
+++ b/source/bin/rocprof-sys-causal/impl.cpp
@@ -819,10 +819,6 @@ parse_args(int argc, char** argv, std::vector<char*>& _env,
     (defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0)
         add_default_env(_env, "ROCPROFSYS_USE_MPIP", true);
 #endif
-
-#if defined(ROCPROFSYS_USE_RCCL) && ROCPROFSYS_USE_RCCL > 0
-        add_default_env(_env, "ROCPROFSYS_USE_RCCLP", true);
-#endif
     }
 
     _fill("ROCPROFSYS_CAUSAL_BINARY_EXCLUDE", _binary_excludes, _generate_configs);

--- a/tests/rocprof-sys-testing.cmake
+++ b/tests/rocprof-sys-testing.cmake
@@ -111,8 +111,14 @@ set(_timemory_environment
 set(_test_environment ${_base_environment})
 
 set(_causal_environment
-    "${_test_openmp_env}" "${_test_library_path}" "ROCPROFSYS_TIME_OUTPUT=OFF"
-    "ROCPROFSYS_FILE_OUTPUT=ON" "ROCPROFSYS_CAUSAL_RANDOM_SEED=1342342")
+    "${_test_openmp_env}" "${_test_library_path}"
+    "ROCPROFSYS_USE_PID=OFF"
+    "ROCPROFSYS_USE_KOKKOSP=ON"
+    "ROCPROFSYS_USE_OMPT=ON"
+    "ROCPROFSYS_USE_MPIP=ON"
+    "ROCPROFSYS_TIME_OUTPUT=OFF"
+    "ROCPROFSYS_FILE_OUTPUT=ON"
+    "ROCPROFSYS_CAUSAL_RANDOM_SEED=1342342")
 
 set(_python_environment
     "ROCPROFSYS_TRACE=ON"
@@ -619,7 +625,7 @@ function(ROCPROFILER_SYSTEMS_ADD_CAUSAL_TEST)
     endif()
 
     if(NOT TEST_CAUSAL_TIMEOUT)
-        set(TEST_CAUSAL_TIMEOUT 600)
+        set(TEST_CAUSAL_TIMEOUT 800)
     endif()
 
     if(NOT TEST_CAUSAL_VALIDATE_TIMEOUT)

--- a/tests/rocprof-sys-testing.cmake
+++ b/tests/rocprof-sys-testing.cmake
@@ -631,8 +631,8 @@ function(ROCPROFILER_SYSTEMS_ADD_CAUSAL_TEST)
     endif()
 
     if(TARGET ${TEST_TARGET})
-        set(COMMAND_PREFIX $<TARGET_FILE:rocprofiler-systems-causal> --reset -m
-                           ${TEST_CAUSAL_MODE} ${TEST_CAUSAL_ARGS} --)
+        set(COMMAND_PREFIX $<TARGET_FILE:rocprofiler-systems-causal> --reset
+                           --no-defaults -m ${TEST_CAUSAL_MODE} ${TEST_CAUSAL_ARGS} --)
 
         if(NOT TEST_SKIP_BASELINE)
             add_test(


### PR DESCRIPTION
We can let the test arguments define the arguments.