### PR TITLE
Update the videodecode ctest

### DIFF
--- a/examples/videodecode/CMakeLists.txt
+++ b/examples/videodecode/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
     videodecode_message(AUTHOR_WARNING "${PROJECT_NAME} skipped. Missing RocDecode ...")
 endif()
 
+# Copy video files to build directory
 if(EXISTS "${ROCmVersion_DIR}/share/rocdecode/video")
     if(NOT EXISTS "${CMAKE_BINARY_DIR}/videos")
         file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/videos")
@@ -79,7 +80,6 @@ if(EXISTS "${ROCmVersion_DIR}/share/rocdecode/video")
 
     file(GLOB_RECURSE video_files "${ROCmVersion_DIR}/share/rocdecode/video/*H26*.mp4")
     file(COPY ${video_files} DESTINATION ${CMAKE_BINARY_DIR}/videos)
-    message(STATUS "Copying video files to ${CMAKE_BINARY_DIR}/videos")
 else()
     videodecode_message(
         AUTHOR_WARNING
@@ -161,7 +161,7 @@ if(FFMPEG_FOUND AND ROCDECODE_FOUND)
             DESTINATION bin
             COMPONENT rocprofiler-systems-examples)
         install(
-            FILES ${PROJECT_BINARY_DIR}/videos
+            FILES ${CMAKE_BINARY_DIR}/videos
             DESTINATION share/rocprofiler-systems/tests/videos
             COMPONENT rocprofiler-systems-examples)
     endif()

--- a/examples/videodecode/CMakeLists.txt
+++ b/examples/videodecode/CMakeLists.txt
@@ -72,6 +72,18 @@ else()
     videodecode_message(AUTHOR_WARNING "${PROJECT_NAME} skipped. Missing RocDecode ...")
 endif()
 
+if(EXISTS "${ROCmVersion_DIR}/share/rocdecode/video")
+    if(NOT EXISTS "${CMAKE_BINARY_DIR}/videos")
+        file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/videos")
+    endif()
+
+    file(GLOB_RECURSE video_files "${ROCmVersion_DIR}/share/rocdecode/video/*H26*.mp4")
+    file(COPY ${video_files} DESTINATION ${CMAKE_BINARY_DIR}/videos)
+    message(STATUS "Copying video files to ${CMAKE_BINARY_DIR}/videos")
+else()
+    videodecode_message(AUTHOR_WARNING "Source directory ${ROCmVersion_DIR}/share/rocdecode/video does not exist")
+endif()
+
 # Find FFMPEG
 find_package(FFmpeg)
 if(NOT FFMPEG_FOUND)
@@ -146,6 +158,10 @@ if(FFMPEG_FOUND AND ROCDECODE_FOUND)
             TARGETS videodecode
             DESTINATION bin
             COMPONENT rocprofiler-systems-examples)
+        install(
+            FILES ${PROJECT_BINARY_DIR}/videos
+            DESTINATION share/rocprofiler-systems/tests/videos
+            COMPONENT rocprofiler-systems-examples)
     endif()
 else()
     message(
@@ -158,3 +174,5 @@ else()
         message(FATAL_ERROR "-- ERROR!: rocDecode Not Found! - please install rocDecode!")
     endif()
 endif()
+
+

--- a/examples/videodecode/CMakeLists.txt
+++ b/examples/videodecode/CMakeLists.txt
@@ -81,7 +81,9 @@ if(EXISTS "${ROCmVersion_DIR}/share/rocdecode/video")
     file(COPY ${video_files} DESTINATION ${CMAKE_BINARY_DIR}/videos)
     message(STATUS "Copying video files to ${CMAKE_BINARY_DIR}/videos")
 else()
-    videodecode_message(AUTHOR_WARNING "Source directory ${ROCmVersion_DIR}/share/rocdecode/video does not exist")
+    videodecode_message(
+        AUTHOR_WARNING
+        "Source directory ${ROCmVersion_DIR}/share/rocdecode/video does not exist")
 endif()
 
 # Find FFMPEG
@@ -174,5 +176,3 @@ else()
         message(FATAL_ERROR "-- ERROR!: rocDecode Not Found! - please install rocDecode!")
     endif()
 endif()
-
-

--- a/tests/rocprof-sys-videodecode-tests.cmake
+++ b/tests/rocprof-sys-videodecode-tests.cmake
@@ -9,7 +9,7 @@ rocprofiler_systems_add_test(
     NAME videodecode
     TARGET videodecode
     GPU ON
-    RUN_ARGS -i ${ROCmVersion_DIR}/share/rocdecode/video/ -t 2
+    RUN_ARGS -i ${PROJECT_BINARY_DIR}/videos -t 2
     LABELS "videodecode")
 
 rocprofiler_systems_add_validation_test(

--- a/tests/rocprof-sys-videodecode-tests.cmake
+++ b/tests/rocprof-sys-videodecode-tests.cmake
@@ -9,7 +9,7 @@ rocprofiler_systems_add_test(
     NAME videodecode
     TARGET videodecode
     GPU ON
-    RUN_ARGS -i ${PROJECT_BINARY_DIR}/videos -t 2
+    RUN_ARGS -i ${PROJECT_BINARY_DIR}/videos -t 1
     LABELS "videodecode")
 
 rocprofiler_systems_add_validation_test(


### PR DESCRIPTION
- Copy sample videos and include in install.
- Only using the H26* videos, so the same tests can be used on MI100, which lacks AV1 decode support
- Update test parameters to `videodecode` test, based on feedback from the rocDecode team.