### PR TITLE
Update RHEL Docker Images & Fix CTest

### DIFF
--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /tmp
 SHELL [ "/bin/bash", "-c" ]
 
-ENV PATH /usr/local/bin:${PATH}
+ENV PATH /usr/lib64/openmpi/bin:/usr/local/bin:${PATH}
 ENV LIBRARY_PATH ${LIBRARY_PATH}:/opt/amdgpu/lib64
 
 RUN yum groupinstall -y "Development Tools" && \

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -18,7 +18,8 @@ RUN yum groupinstall -y "Development Tools" && \
     yum install -y --allowerasing cmake curl dpkg-devel numactl-devel openmpi-devel \
         papi-devel python3-pip texinfo wget which zlib-devel && \
     yum clean all && \
-    python3 -m pip install 'cmake==3.21'
+    python3 -m pip install 'cmake==3.21' && \
+    python3 -m pip install 'perfetto'
 
 ARG ROCM_VERSION=0.0
 ARG AMDGPU_RPM=6.2/rhel/9.4/amdgpu-install-6.2.60202-1.el9.noarch.rpm

--- a/docker/Dockerfile.rhel.ci
+++ b/docker/Dockerfile.rhel.ci
@@ -22,7 +22,8 @@ RUN yum groupinstall -y "Development Tools" && \
     yum install -y --allowerasing cmake curl dpkg-devel numactl-devel \
         openmpi-devel papi-devel python3-pip texinfo wget which zlib-devel && \
     yum clean all && \
-    python3 -m pip install 'cmake==3.21'
+    python3 -m pip install 'cmake==3.21' && \
+    python3 -m pip install 'perfetto'
 
 COPY ./dyninst-source /tmp/dyninst
 

--- a/docker/Dockerfile.rhel.ci
+++ b/docker/Dockerfile.rhel.ci
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /tmp
 SHELL [ "/bin/bash", "-c" ]
 
-ENV PATH /usr/local/bin:${PATH}
+ENV PATH /usr/lib64/openmpi/bin:/usr/local/bin:${PATH}
 
 ARG EXTRA_PACKAGES=""
 ARG ELFUTILS_DOWNLOAD_VERSION="0.188"

--- a/tests/rocprof-sys-attach-tests.cmake
+++ b/tests/rocprof-sys-attach-tests.cmake
@@ -30,7 +30,7 @@ endif()
 add_test(
     NAME parallel-overhead-attach
     COMMAND
-        ${CMAKE_CURRENT_LIST_DIR}/run-rocprofiler-systems-pid.sh
+        ${CMAKE_CURRENT_LIST_DIR}/run-rocprof-sys-pid.sh
         $<TARGET_FILE:rocprofiler-systems-instrument> -ME "\.c$" -E fib -e -v 1 --label
         return args file -l -- $<TARGET_FILE:parallel-overhead> 30 8 1000
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})


### PR DESCRIPTION
- Fixed type in script name to fix CTest. Should be: `run-rocprof-sys-pid.sh`
- Add `/usr/lib64/openmpi/bin` to Docker Image PATH
- `pip install perfetto` in the CI Docker file for convenience.