### PR TITLE
Fix rocprof-sys-instrument default linkage and visibility criteria

### DIFF
--- a/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -144,9 +144,11 @@ regexvec_t       instruction_exclude           = {};
 CodeCoverageMode coverage_mode                 = CODECOV_NONE;
 
 symtab_data_s                 symtab_data        = {};
-std::set<symbol_linkage_t>    enabled_linkage    = { SL_GLOBAL, SL_LOCAL, SL_UNIQUE };
-std::set<symbol_visibility_t> enabled_visibility = { SV_DEFAULT, SV_HIDDEN, SV_INTERNAL,
-                                                     SV_PROTECTED };
+std::set<symbol_linkage_t>    enabled_linkage    = {};
+std::set<symbol_visibility_t> enabled_visibility = {};
+const std::set<symbol_linkage_t>    default_enabled_linkage    = { SL_GLOBAL, SL_LOCAL, SL_UNIQUE };
+const std::set<symbol_visibility_t> default_enabled_visibility = { SV_DEFAULT, SV_HIDDEN, SV_INTERNAL,
+                                                                   SV_PROTECTED };
 
 std::unique_ptr<std::ofstream> log_ofs = {};
 
@@ -835,30 +837,30 @@ main(int argc, char** argv)
         return _ret;
     };
 
+    enabled_linkage = default_enabled_linkage;
     parser
         .add_argument({ "--linkage" },
                       join("",
                            "Only instrument functions with specified linkage (default: ",
-                           join(array_config{ ", ", "", "" }, enabled_linkage), ")"))
+                           join(array_config{ ", ", "", "" }, default_enabled_linkage), ")"))
         .min_count(1)
         .choices(available_linkage)
-        .set_default(_get_strvec(enabled_linkage))
+        .set_default(_get_strvec(default_enabled_linkage))
         .action([](parser_t& p) {
-            enabled_linkage.clear();
             for(const auto& itr : p.get<std::set<std::string>>("linkage"))
                 enabled_linkage.emplace(from_string<symbol_linkage_t>(itr));
         });
 
+    enabled_visibility = default_enabled_visibility;
     parser
         .add_argument(
             { "--visibility" },
             join("", "Only instrument functions with specified visibility (default: ",
-                 join(array_config{ ", ", "", "" }, enabled_visibility), ")"))
+                 join(array_config{ ", ", "", "" }, default_enabled_visibility), ")"))
         .min_count(1)
         .choices(available_visibility)
-        .set_default(_get_strvec(enabled_visibility))
+        .set_default(_get_strvec(default_enabled_visibility))
         .action([](parser_t& p) {
-            enabled_visibility.clear();
             for(const auto& itr : p.get<std::set<std::string>>("visibility"))
                 enabled_visibility.emplace(from_string<symbol_visibility_t>(itr));
         });

--- a/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -849,7 +849,6 @@ main(int argc, char** argv)
         .choices(available_linkage)
         .set_default(_get_strvec(default_enabled_linkage))
         .action([](parser_t& p) {
-            enabled_linkage.clear();
             for(const auto& itr : p.get<std::set<std::string>>("linkage"))
                 enabled_linkage.emplace(from_string<symbol_linkage_t>(itr));
         });
@@ -864,7 +863,6 @@ main(int argc, char** argv)
         .choices(available_visibility)
         .set_default(_get_strvec(default_enabled_visibility))
         .action([](parser_t& p) {
-            enabled_visibility.clear();
             for(const auto& itr : p.get<std::set<std::string>>("visibility"))
                 enabled_visibility.emplace(from_string<symbol_visibility_t>(itr));
         });

--- a/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -143,11 +143,13 @@ regexvec_t       file_internal_include         = {};
 regexvec_t       instruction_exclude           = {};
 CodeCoverageMode coverage_mode                 = CODECOV_NONE;
 
-symtab_data_s                 symtab_data        = {};
-std::set<symbol_linkage_t>    enabled_linkage    = {};
-std::set<symbol_visibility_t> enabled_visibility = {};
-const std::set<symbol_linkage_t>    default_enabled_linkage    = { SL_GLOBAL, SL_LOCAL, SL_UNIQUE };
-const std::set<symbol_visibility_t> default_enabled_visibility = { SV_DEFAULT, SV_HIDDEN, SV_INTERNAL,
+symtab_data_s                       symtab_data                = {};
+std::set<symbol_linkage_t>          enabled_linkage            = {};
+std::set<symbol_visibility_t>       enabled_visibility         = {};
+const std::set<symbol_linkage_t>    default_enabled_linkage    = { SL_GLOBAL, SL_LOCAL,
+                                                                   SL_UNIQUE };
+const std::set<symbol_visibility_t> default_enabled_visibility = { SV_DEFAULT, SV_HIDDEN,
+                                                                   SV_INTERNAL,
                                                                    SV_PROTECTED };
 
 std::unique_ptr<std::ofstream> log_ofs = {};
@@ -270,8 +272,8 @@ activate_signal_handlers(const std::vector<sys_signal>& _signals)
         TIMEMORY_PRINTF_FATAL(
             stderr,
             "These were the last %i log entries from rocprof-sys. You can control the "
-            "number of log entries via the '--log <N>' option or ROCPROFSYS_LOG_COUNT "
-            "env variable.\n",
+                   "number of log entries via the '--log <N>' option or ROCPROFSYS_LOG_COUNT "
+                   "env variable.\n",
             num_log_entries);
 
         if(log_ofs) log_ofs->close();
@@ -839,10 +841,10 @@ main(int argc, char** argv)
 
     enabled_linkage = default_enabled_linkage;
     parser
-        .add_argument({ "--linkage" },
-                      join("",
-                           "Only instrument functions with specified linkage (default: ",
-                           join(array_config{ ", ", "", "" }, default_enabled_linkage), ")"))
+        .add_argument(
+            { "--linkage" },
+            join("", "Only instrument functions with specified linkage (default: ",
+                 join(array_config{ ", ", "", "" }, default_enabled_linkage), ")"))
         .min_count(1)
         .choices(available_linkage)
         .set_default(_get_strvec(default_enabled_linkage))
@@ -1688,7 +1690,7 @@ main(int argc, char** argv)
     auto* user_start_func = find_function(app_image, "rocprofsys_user_start_trace",
                                           { "rocprofsys_user_start_thread_trace" });
     auto* user_stop_func  = find_function(app_image, "rocprofsys_user_stop_trace",
-                                         { "rocprofsys_user_stop_thread_trace" });
+                                          { "rocprofsys_user_stop_thread_trace" });
 #if ROCPROFSYS_USE_MPI > 0 || ROCPROFSYS_USE_MPI_HEADERS > 0
     // if any of the below MPI functions are found, enable MPI support
     for(const auto* itr : { "MPI_Init", "MPI_Init_thread", "MPI_Finalize",

--- a/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -849,8 +849,13 @@ main(int argc, char** argv)
         .choices(available_linkage)
         .set_default(_get_strvec(default_enabled_linkage))
         .action([](parser_t& p) {
-            for(const auto& itr : p.get<std::set<std::string>>("linkage"))
-                enabled_linkage.emplace(from_string<symbol_linkage_t>(itr));
+            auto selected_linkage = p.get<std::set<std::string>>("linkage");
+            if(!selected_linkage.empty())
+            {
+                enabled_linkage.clear();
+                for(const auto& itr : selected_linkage)
+                    enabled_linkage.emplace(from_string<symbol_linkage_t>(itr));
+            }
         });
 
     enabled_visibility = default_enabled_visibility;
@@ -863,8 +868,13 @@ main(int argc, char** argv)
         .choices(available_visibility)
         .set_default(_get_strvec(default_enabled_visibility))
         .action([](parser_t& p) {
-            for(const auto& itr : p.get<std::set<std::string>>("visibility"))
-                enabled_visibility.emplace(from_string<symbol_visibility_t>(itr));
+            auto selected_visibility = p.get<std::set<std::string>>("visibility");
+            if(!selected_visibility.empty())
+            {
+                enabled_visibility.clear();
+                for(const auto& itr : selected_visibility)
+                    enabled_visibility.emplace(from_string<symbol_visibility_t>(itr));
+            }
         });
 
     parser.add_argument({ "" }, "");

--- a/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -844,9 +844,10 @@ main(int argc, char** argv)
         .add_argument(
             { "--linkage" },
             join("", "Only instrument functions with specified linkage (default: ",
-                 join(array_config{ ", ", "", "" }, default_enabled_linkage), ")"))
+                 join(array_config{ ", ", "", "" }, _get_strvec(default_enabled_linkage)),
+                 ")"))
         .min_count(1)
-        .choices(available_linkage)
+        .choices(_get_strvec(available_linkage))
         .set_default(_get_strvec(default_enabled_linkage))
         .action([](parser_t& p) {
             auto selected_linkage = p.get<std::set<std::string>>("linkage");
@@ -863,9 +864,11 @@ main(int argc, char** argv)
         .add_argument(
             { "--visibility" },
             join("", "Only instrument functions with specified visibility (default: ",
-                 join(array_config{ ", ", "", "" }, default_enabled_visibility), ")"))
+                 join(array_config{ ", ", "", "" },
+                      _get_strvec(default_enabled_visibility)),
+                 ")"))
         .min_count(1)
-        .choices(available_visibility)
+        .choices(_get_strvec(available_visibility))
         .set_default(_get_strvec(default_enabled_visibility))
         .action([](parser_t& p) {
             auto selected_visibility = p.get<std::set<std::string>>("visibility");

--- a/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -147,7 +147,7 @@ symtab_data_s                       symtab_data                = {};
 std::set<symbol_linkage_t>          enabled_linkage            = {};
 std::set<symbol_visibility_t>       enabled_visibility         = {};
 const std::set<symbol_linkage_t>    default_enabled_linkage    = { SL_GLOBAL, SL_LOCAL,
-                                                                   SL_UNIQUE };
+                                                             SL_UNIQUE };
 const std::set<symbol_visibility_t> default_enabled_visibility = { SV_DEFAULT, SV_HIDDEN,
                                                                    SV_INTERNAL,
                                                                    SV_PROTECTED };
@@ -272,8 +272,8 @@ activate_signal_handlers(const std::vector<sys_signal>& _signals)
         TIMEMORY_PRINTF_FATAL(
             stderr,
             "These were the last %i log entries from rocprof-sys. You can control the "
-                   "number of log entries via the '--log <N>' option or ROCPROFSYS_LOG_COUNT "
-                   "env variable.\n",
+            "number of log entries via the '--log <N>' option or ROCPROFSYS_LOG_COUNT "
+            "env variable.\n",
             num_log_entries);
 
         if(log_ofs) log_ofs->close();
@@ -1703,7 +1703,7 @@ main(int argc, char** argv)
     auto* user_start_func = find_function(app_image, "rocprofsys_user_start_trace",
                                           { "rocprofsys_user_start_thread_trace" });
     auto* user_stop_func  = find_function(app_image, "rocprofsys_user_stop_trace",
-                                          { "rocprofsys_user_stop_thread_trace" });
+                                         { "rocprofsys_user_stop_thread_trace" });
 #if ROCPROFSYS_USE_MPI > 0 || ROCPROFSYS_USE_MPI_HEADERS > 0
     // if any of the below MPI functions are found, enable MPI support
     for(const auto* itr : { "MPI_Init", "MPI_Init_thread", "MPI_Finalize",

--- a/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -849,6 +849,7 @@ main(int argc, char** argv)
         .choices(available_linkage)
         .set_default(_get_strvec(default_enabled_linkage))
         .action([](parser_t& p) {
+            enabled_linkage.clear();
             for(const auto& itr : p.get<std::set<std::string>>("linkage"))
                 enabled_linkage.emplace(from_string<symbol_linkage_t>(itr));
         });
@@ -863,6 +864,7 @@ main(int argc, char** argv)
         .choices(available_visibility)
         .set_default(_get_strvec(default_enabled_visibility))
         .action([](parser_t& p) {
+            enabled_visibility.clear();
             for(const auto& itr : p.get<std::set<std::string>>("visibility"))
                 enabled_visibility.emplace(from_string<symbol_visibility_t>(itr));
         });


### PR DESCRIPTION
Tested with gfortran 13 and 14 on Ubuntu 24.04.
Need wider testing coverage on earlier gfortran versions, crayftn, and amdflang (both current and next-gen)