### PR TITLE
Added libamd_comgr.so to the list of internal modules

### DIFF
--- a/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -330,7 +330,8 @@ get_internal_basic_libs_impl()
                                             "librocprofiler-register.so",
                                             "librocprofiler-sdk.so",
                                             "librocprofiler-sdk-roctx.so",
-                                            "libamd_smi.so" };
+                                            "libamd_smi.so",
+                                            "libamd_comgr.so"};
 
     // shared libraries potentially used by timemory
     const auto _3rdparty_libs = strview_init_t{ "libcaliper.so",

--- a/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -331,7 +331,7 @@ get_internal_basic_libs_impl()
                                             "librocprofiler-sdk.so",
                                             "librocprofiler-sdk-roctx.so",
                                             "libamd_smi.so",
-                                            "libamd_comgr.so"};
+                                            "libamd_comgr.so" };
 
     // shared libraries potentially used by timemory
     const auto _3rdparty_libs = strview_init_t{ "libcaliper.so",


### PR DESCRIPTION
libamd_comgr.so should not be instrumented when we run rocprof-systems-instrument.