### PR TITLE
Fix logging error

### DIFF
--- a/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -133,6 +133,7 @@ create_agent_profile(rocprofiler_agent_id_t          agent_id,
 
             ROCPROFSYS_PRINT_F("tool agent device id=%lu, name=%s, device_id=%lu\n",
                                tool_agent_v->device_id, name_v.c_str(), dev_id_v);
+
             // skip this counter if the counter is for a specific device id (which
             // doesn't this agent's device id)
             if(dev_id_v != tool_agent_v->device_id)
@@ -142,13 +143,23 @@ create_agent_profile(rocprofiler_agent_id_t          agent_id,
             }
         }
 
+        // Removes any numeric index enclosed in square brackets at the end of the string.
+        // For example, "example[123]" will be converted to "example".
         auto _old_name_v = name_v;
         name_v =
             std::regex_replace(name_v, std::regex{ "^(.*)(\\[)([0-9]+)(\\])$" }, "$1");
+
         if(name_v != _old_name_v)
+        {
             ROCPROFSYS_PRINT_F("tool agent device id=%lu, old_name=%s, name=%s\n",
                                tool_agent_v->device_id, _old_name_v.c_str(),
                                name_v.c_str());
+        }
+        else if(name_v == itr)
+        {
+            ROCPROFSYS_PRINT_F("tool agent device id=%lu, name=%s\n",
+                               tool_agent_v->device_id, name_v.c_str());
+        }
 
         // search the gpu agent counter info for a counter with a matching name
         for(const auto& citr : data->agent_counter_info.at(agent_id))


### PR DESCRIPTION
When we create profile config with rocprofiler we log the counters being registered. However, this log was being skipped in certain cases.