### PR TITLE
Fix for upgrade from omnitrace to rocprofiler-systems

### DIFF
--- a/cmake/ConfigCPack.cmake
+++ b/cmake/ConfigCPack.cmake
@@ -185,8 +185,8 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
 # Handle the project rebranding from "omnitrace" to "rocprofiler-systems"
 set(CPACK_DEBIAN_PACKAGE_PROVIDES ${OMNITRACE_PACKAGE_NAME})
-set(CPACK_DEBIAN_PACKAGE_REPLACES ${OMNITRACE_PACKAGE_NAME})
-set(CPACK_DEBIAN_PACKAGE_BREAKS ${OMNITRACE_PACKAGE_NAME})
+set(CPACK_DEBIAN_PACKAGE_REPLACES "${OMNITRACE_PACKAGE_NAME} (<< 2.0.0)")
+set(CPACK_DEBIAN_PACKAGE_BREAKS "${OMNITRACE_PACKAGE_NAME} (<< 2.0.0)")
 
 # -------------------------------------------------------------------------------------- #
 #


### PR DESCRIPTION
The fix proposed is to explicitly mention the version number for replacement.

Omnitrace version number which could be a bigger than the version number for rocprofiler-systems could be a reason why the upgrade fails with the message "omnitrace is already the newest version (1.11.2.60204-139~22.04)."