### PR TITLE
[6.4] Update libraries' SOVERSION to match other ROCm components (#98)

### DIFF
--- a/source/lib/rocprof-sys-dl/CMakeLists.txt
+++ b/source/lib/rocprof-sys-dl/CMakeLists.txt
@@ -41,7 +41,7 @@ set_target_properties(
     rocprofiler-systems-dl-library
     PROPERTIES OUTPUT_NAME ${BINARY_NAME_PREFIX}-dl
                VERSION ${PROJECT_VERSION}
-               SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+               SOVERSION ${PROJECT_VERSION_MAJOR}
                BUILD_RPATH "\$ORIGIN"
                INSTALL_RPATH "\$ORIGIN")
 

--- a/source/lib/rocprof-sys-rt/CMakeLists.txt
+++ b/source/lib/rocprof-sys-rt/CMakeLists.txt
@@ -112,7 +112,7 @@ set_target_properties(
     rocprofiler-systems-rt-library
     PROPERTIES OUTPUT_NAME ${BINARY_NAME_PREFIX}-rt
                VERSION ${PROJECT_VERSION}
-               SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+               SOVERSION ${PROJECT_VERSION_MAJOR}
                BUILD_RPATH "\$ORIGIN"
                INSTALL_RPATH "\$ORIGIN")
 

--- a/source/lib/rocprof-sys-user/CMakeLists.txt
+++ b/source/lib/rocprof-sys-user/CMakeLists.txt
@@ -36,7 +36,7 @@ set_target_properties(
     rocprofiler-systems-user-library
     PROPERTIES OUTPUT_NAME ${BINARY_NAME_PREFIX}-user
                VERSION ${PROJECT_VERSION}
-               SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+               SOVERSION ${PROJECT_VERSION_MAJOR}
                POSITION_INDEPENDENT_CODE ON
                BUILD_RPATH "\$ORIGIN"
                INSTALL_RPATH "\$ORIGIN")

--- a/source/lib/rocprof-sys/CMakeLists.txt
+++ b/source/lib/rocprof-sys/CMakeLists.txt
@@ -62,7 +62,7 @@ set_target_properties(
     rocprofiler-systems-shared-library
     PROPERTIES OUTPUT_NAME ${BINARY_NAME_PREFIX}
                VERSION ${PROJECT_VERSION}
-               SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+               SOVERSION ${PROJECT_VERSION_MAJOR}
                INSTALL_RPATH "${ROCPROFSYS_LIB_INSTALL_RPATH}")
 
 rocprofiler_systems_strip_target(rocprofiler-systems-shared-library)


### PR DESCRIPTION
set SOVERSION to ${PROJECT_VERSION_MAJOR}