### PR TITLE
Fix for excluding JPEG and VCN activity test.

### DIFF
--- a/examples/jpegdecode/CMakeLists.txt
+++ b/examples/jpegdecode/CMakeLists.txt
@@ -57,32 +57,34 @@ if(ROCPROFSYS_DISABLE_EXAMPLES)
     endif()
 endif()
 
-# Copy image files to build directory
-if(EXISTS "${ROCmVersion_DIR}/share/rocjpeg/images")
-    if(NOT EXISTS "${CMAKE_BINARY_DIR}/images")
-        file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/images")
-    endif()
-
-    file(GLOB_RECURSE image_files "${ROCmVersion_DIR}/share/rocjpeg/images/*")
-    file(COPY ${image_files} DESTINATION ${CMAKE_BINARY_DIR}/images)
-    set(NUM_COPIES 20)
-
-    # Loop over each file and make additional copies
-    foreach(file ${image_files})
-        get_filename_component(filename ${file} NAME)
-        foreach(i RANGE 1 ${NUM_COPIES})
-            file(COPY ${file}
-                 DESTINATION ${CMAKE_BINARY_DIR}/images/${filename}_copy${i}.jpg)
-        endforeach()
-    endforeach()
-else()
-    message(
-        AUTHOR_WARNING
-            "Source directory ${ROCmVersion_DIR}/share/rocjpeg/images does not exist")
-endif()
-
 find_package(rocJPEG QUIET)
 find_package(rocprofiler-register QUIET)
+
+# Copy image files to build directory
+function(copy_image_files_and_make_copies)
+    if(EXISTS "${ROCmVersion_DIR}/share/rocjpeg/images")
+        if(NOT EXISTS "${CMAKE_BINARY_DIR}/images")
+            file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/images")
+        endif()
+
+        file(GLOB_RECURSE image_files "${ROCmVersion_DIR}/share/rocjpeg/images/*")
+        file(COPY ${image_files} DESTINATION ${CMAKE_BINARY_DIR}/images)
+        set(NUM_COPIES 20)
+
+        # Loop over each file and make additional copies
+        foreach(file ${image_files})
+            get_filename_component(filename ${file} NAME)
+            foreach(i RANGE 1 ${NUM_COPIES})
+                file(COPY ${file}
+                     DESTINATION ${CMAKE_BINARY_DIR}/images/${filename}_copy${i}.jpg)
+            endforeach()
+        endforeach()
+    else()
+        message(
+            AUTHOR_WARNING
+                "Source directory ${ROCmVersion_DIR}/share/rocjpeg/images does not exist")
+    endif()
+endfunction()
 
 # threads
 find_package(Threads REQUIRED)
@@ -109,6 +111,7 @@ if(HIP_FOUND
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
     target_link_libraries(jpegdecode ${LINK_LIBRARY_LIST})
     target_compile_options(jpegdecode PRIVATE ${_FLAGS})
+    copy_image_files_and_make_copies()
 
     if(ROCPROFSYS_INSTALL_EXAMPLES)
         install(

--- a/tests/rocprof-sys-decode-tests.cmake
+++ b/tests/rocprof-sys-decode-tests.cmake
@@ -15,6 +15,15 @@ set(_jpeg_decode_environment
     "ROCPROFSYS_ROCM_SMI_METRICS=busy,temp,power,jpeg_activity,mem_usage"
     "ROCPROFSYS_SAMPLING_CPUS=none")
 
+check_gpu("MI300" MI300_DETECTED)
+if(MI300_DETECTED)
+    list(APPEND VCN_COUNTER_NAMES_ARG --counter-names "VCN Activity")
+    list(APPEND JPEG_COUNTER_NAMES_ARG --counter-names "JPEG Activity")
+endif()
+
+# check_gpu("MI100" MI100_DETECTED) if(MI100_DETECTED) list(APPEND VCN_COUNTER_NAMES_ARG
+# --counter-names "VCN Activity") endif()
+
 rocprofiler_systems_add_test(
     SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
     NAME video-decode
@@ -29,15 +38,7 @@ rocprofiler_systems_add_validation_test(
     PERFETTO_METRIC "rocm_rocdecode_api"
     PERFETTO_FILE "perfetto-trace.proto"
     LABELS "decode"
-    ARGS -l
-         rocDecCreateVideoParser
-         -c
-         2
-         -d
-         1
-         --counter-names
-         "VCN Activity"
-         -p)
+    ARGS -l rocDecCreateVideoParser -c 2 -d 1 ${VCN_COUNTER_NAMES_ARG} -p)
 
 # -------------------------------------------------------------------------------------- #
 #
@@ -59,12 +60,4 @@ rocprofiler_systems_add_validation_test(
     PERFETTO_METRIC "rocm_rocjpeg_api"
     PERFETTO_FILE "perfetto-trace.proto"
     LABELS "decode"
-    ARGS -l
-         rocJpegCreate
-         -c
-         1
-         -d
-         1
-         --counter-names
-         "JPEG Activity"
-         -p)
+    ARGS -l rocJpegCreate -c 1 -d 1 ${JPEG_COUNTER_NAMES_ARG} -p)

--- a/tests/rocprof-sys-testing.cmake
+++ b/tests/rocprof-sys-testing.cmake
@@ -282,6 +282,31 @@ endmacro()
 
 # -------------------------------------------------------------------------------------- #
 
+# Define the function to check for a specific GPU
+function(check_gpu gpu_name return_var)
+    # Run the rocminfo command and capture the output
+    execute_process(
+        COMMAND rocminfo | grep ${gpu_name}
+        OUTPUT_VARIABLE ROCMINFO_OUTPUT
+        RESULT_VARIABLE ROCMINFO_RESULT
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    # Check if the specified GPU is present
+    if(ROCMINFO_RESULT EQUAL 0)
+        message(STATUS "${gpu_name} GPU detected")
+        set(${return_var}
+            TRUE
+            PARENT_SCOPE)
+    else()
+        message(STATUS "${gpu_name} GPU not detected")
+        set(${return_var}
+            FALSE
+            PARENT_SCOPE)
+    endif()
+endfunction()
+
+# -------------------------------------------------------------------------------------- #
+
 function(ROCPROFILER_SYSTEMS_WRITE_TEST_CONFIG _FILE _ENV)
     set(_ENV_ONLY
         "ROCPROFSYS_(CI|CI_TIMEOUT|MODE|USE_MPIP|DEBUG_[A-Z_]+|FORCE_ROCPROFILER_INIT|DEFAULT_MIN_INSTRUCTIONS|MONOCHROME|VERBOSE)="


### PR DESCRIPTION
JPEG activity recording is currently only supported on MI300 serries. VCN activity is supported in MI100 also but there is a bug currently being fixed by FW.

- Only test the JPEG and VCN Activity verification tests on MI300 now.
- Moves the Jpeg image copying code to after the package is found.