### PR TITLE
rocprof-sys-run: Change terminal color back to normal after printing usage

### DIFF
--- a/source/bin/rocprof-sys-run/rocprof-sys-run.cpp
+++ b/source/bin/rocprof-sys-run/rocprof-sys-run.cpp
@@ -52,7 +52,8 @@ main(int argc, char** argv)
 
     auto _print_usage = [argv]() {
         std::cerr << tim::log::color::fatal() << "Usage: " << argv[0]
-                  << " <OPTIONS> -- <COMMAND> <ARGS>" << tim::log::color::end() << std::endl;
+                  << " <OPTIONS> -- <COMMAND> <ARGS>" << tim::log::color::end()
+                  << std::endl;
     };
 
     if(argc == 1)

--- a/source/bin/rocprof-sys-run/rocprof-sys-run.cpp
+++ b/source/bin/rocprof-sys-run/rocprof-sys-run.cpp
@@ -52,7 +52,7 @@ main(int argc, char** argv)
 
     auto _print_usage = [argv]() {
         std::cerr << tim::log::color::fatal() << "Usage: " << argv[0]
-                  << " <OPTIONS> -- <COMMAND> <ARGS>" << std::endl;
+                  << " <OPTIONS> -- <COMMAND> <ARGS>" << tim::log::color::end() << std::endl;
     };
 
     if(argc == 1)


### PR DESCRIPTION
When printing rocprof-sys-run usage, terminal text color was set to red but not set back to normal after:

![image](https://github.com/user-attachments/assets/05049d6c-6a95-45ab-86f5-da4505b85b23)
