### PR TITLE
Fix rocprofiler-sdk includes

### DIFF
--- a/source/lib/rocprof-sys/library/rocprofiler-sdk/fwd.hpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk/fwd.hpp
@@ -28,6 +28,7 @@
 #include <rocprofiler-sdk/agent.h>
 #include <rocprofiler-sdk/buffer_tracing.h>
 #include <rocprofiler-sdk/callback_tracing.h>
+#include <rocprofiler-sdk/counters.h>
 #include <rocprofiler-sdk/cxx/hash.hpp>
 #include <rocprofiler-sdk/cxx/name_info.hpp>
 #include <rocprofiler-sdk/cxx/operators.hpp>


### PR DESCRIPTION
Fixes build failure after recent rocprofiler-sdk change (SWDEV-526973).