### PR TITLE
Update the "nic-performance" test

### DIFF
--- a/tests/rocprof-sys-nic-perf.cmake
+++ b/tests/rocprof-sys-nic-perf.cmake
@@ -49,7 +49,7 @@ set(_download_url
 add_test(
     NAME nic-performance
     COMMAND $<TARGET_FILE:rocprofiler-systems-sample> -- wget --no-check-certificate
-            --quiet ${_download_url} -O /tmp/rocprofiler-systems-install.sh
+            ${_download_url} -O /tmp/rocprofiler-systems-install.sh
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
 set_tests_properties(nic-performance PROPERTIES ENVIRONMENT "${_nic_perf_environment}"


### PR DESCRIPTION
- remove the "--quiet" flag
- better logging
- test runs longer and hence collects more samples