### PR TITLE
Loading rccl libraries in ROCm related directory

### DIFF
--- a/source/lib/rocprof-sys/library/rcclp.cpp
+++ b/source/lib/rocprof-sys/library/rcclp.cpp
@@ -58,13 +58,13 @@ setup()
 
     // make sure the symbols are loaded to be wrapped
     dynamic_library _librccl{ "ROCPROFSYS_RCCL_LIBRARY",
-        find_library_path("librccl.so",
-                          { "ROCPROFSYS_ROCM_PATH", "ROCM_PATH" },
-                          { ROCPROFSYS_DEFAULT_ROCM_PATH }),
-        RTLD_NOW | RTLD_GLOBAL,
-        true,
-        true,
-        true };
+                              find_library_path("librccl.so",
+                                                { "ROCPROFSYS_ROCM_PATH", "ROCM_PATH" },
+                                                { ROCPROFSYS_DEFAULT_ROCM_PATH }),
+                              RTLD_NOW | RTLD_GLOBAL,
+                              true,
+                              true,
+                              true };
     auto _use_data = tim::get_env("ROCPROFSYS_RCCLP_COMM_DATA", get_use_timemory());
     if(!get_use_timemory())
     {

--- a/source/lib/rocprof-sys/library/rcclp.cpp
+++ b/source/lib/rocprof-sys/library/rcclp.cpp
@@ -58,9 +58,10 @@ setup()
 
     // make sure the symbols are loaded to be wrapped
     dynamic_library _librccl{
-        "ROCPROFSYS_RCCL_LIBRARY", "librccl.so", RTLD_NOW | RTLD_GLOBAL, true, true, true
+        "ROCPROFSYS_RCCL_LIBRARY", find_library_path("librccl.so",
+            { "ROCPROFSYS_ROCM_PATH", "ROCM_PATH" },
+            { ROCPROFSYS_DEFAULT_ROCM_PATH }), RTLD_NOW | RTLD_GLOBAL, true, true, true
     };
-
     auto _use_data = tim::get_env("ROCPROFSYS_RCCLP_COMM_DATA", get_use_timemory());
     if(!get_use_timemory())
     {

--- a/source/lib/rocprof-sys/library/rcclp.cpp
+++ b/source/lib/rocprof-sys/library/rcclp.cpp
@@ -57,11 +57,14 @@ setup()
     configure();
 
     // make sure the symbols are loaded to be wrapped
-    dynamic_library _librccl{
-        "ROCPROFSYS_RCCL_LIBRARY", find_library_path("librccl.so",
-            { "ROCPROFSYS_ROCM_PATH", "ROCM_PATH" },
-            { ROCPROFSYS_DEFAULT_ROCM_PATH }), RTLD_NOW | RTLD_GLOBAL, true, true, true
-    };
+    dynamic_library _librccl{ "ROCPROFSYS_RCCL_LIBRARY",
+        find_library_path("librccl.so",
+                          { "ROCPROFSYS_ROCM_PATH", "ROCM_PATH" },
+                          { ROCPROFSYS_DEFAULT_ROCM_PATH }),
+        RTLD_NOW | RTLD_GLOBAL,
+        true,
+        true,
+        true };
     auto _use_data = tim::get_env("ROCPROFSYS_RCCLP_COMM_DATA", get_use_timemory());
     if(!get_use_timemory())
     {


### PR DESCRIPTION
This fix is to load rccl libraries in ROCm related directory