### PR TITLE
Fix build failure for the openmp-target example when building in docker.

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -231,6 +231,15 @@ parse:
         TIMEMORY_FILE: '*'
         TIMEMORY_METRIC: '*'
         EXIST_FILES: '*'
+    rocprofiler_systems_custom_compilation:
+      flags:
+        - GLOBAL
+        - PROJECT
+      kwargs:
+        COMPILER: '*'
+        DIRECTORY: '*'
+        TARGET: '*'
+        SOURCE: '*'
   override_spec: {}
   vartags: []
   proptags: []

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -38,12 +38,12 @@ else()
        AND USE_CLANG_OMP)
         target_compile_options(openmp-common PUBLIC -W -Wall -fopenmp=libomp)
         target_link_libraries(openmp-common PUBLIC ${LIBOMP_LIBRARY})
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE} TARGET
-                                               openmp-common)
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE} TARGET
-                                               openmp-cg)
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE} TARGET
-                                               openmp-lu)
+        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                               TARGET openmp-common)
+        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                               TARGET openmp-cg)
+        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                               TARGET openmp-lu)
         set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
             ON
             CACHE INTERNAL "Used by rocprofiler-systems testing" FORCE)

--- a/examples/openmp/target/CMakeLists.txt
+++ b/examples/openmp/target/CMakeLists.txt
@@ -92,8 +92,8 @@ set_target_properties(
                OUTPUT_NAME "openmp-target"
                POSITION_INDEPENDENT_CODE ON)
 
-rocprofiler_systems_custom_compilation(TARGET openmp-target-lib COMPILER
-                                       ${OMP_TARGET_COMPILER})
+rocprofiler_systems_custom_compilation(TARGET openmp-target-lib
+                                       COMPILER ${OMP_TARGET_COMPILER})
 
 add_executable(openmp-target)
 target_sources(openmp-target PRIVATE main.cpp)
@@ -106,5 +106,5 @@ set_target_properties(
                "${OMP_TARGET_COMPILER_DIR}/llvm/lib:${OMP_TARGET_COMPILER_DIR}/lib"
                POSITION_INDEPENDENT_CODE ON)
 
-rocprofiler_systems_custom_compilation(TARGET openmp-target COMPILER
-                                       ${OMP_TARGET_COMPILER})
+rocprofiler_systems_custom_compilation(TARGET openmp-target
+                                       COMPILER ${OMP_TARGET_COMPILER})

--- a/scripts/rocprof-sys-launch-compiler
+++ b/scripts/rocprof-sys-launch-compiler
@@ -93,6 +93,13 @@ else
     # discard the compiler from the command
     shift
 
+    if [ -n "$(basename ${ROCPROFSYS_COMPILER} | egrep 'amdclang|amdllvm')" ]; then
+        # this ensures the libomptarget-amdgpu-gfx*.bc files are found
+        LLVM_LIB_DIR=$(cd $(dirname $(realpath ${ROCPROFSYS_COMPILER}))/../lib && pwd)
+        debug-message export LIBRARY_PATH=${LLVM_LIB_DIR}:${LIBRARY_PATH}
+        export LIBRARY_PATH=${LLVM_LIB_DIR}:${LIBRARY_PATH}
+    fi
+
     debug-message ${ROCPROFSYS_COMPILER} $@
     # execute ${ROCPROFSYS_COMPILER} (again, usually nvcc_wrapper)
     ${ROCPROFSYS_COMPILER} $@


### PR DESCRIPTION
Observed in primarily in docker images
Ensure `libomptarget-amdgpu-gfx*.bc` files are found