### PR TITLE
ROCPROFSYS_AMD_SMI_METRICS visibility

### DIFF
--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -631,7 +631,7 @@ configure_settings(bool _init)
                               "amd-smi metrics to collect: busy, temp, power, "
                               "vcn_activity, jpeg_activity, mem_usage. "
                               "An empty value implies 'all' and 'none' suppresses all.",
-                              "busy, temp, power, mem_usage, vcn_activity, jpeg_activity",
+                              "busy, temp, power, mem_usage",
                               "backend", "amd_smi", "rocm", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB",

--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -631,8 +631,8 @@ configure_settings(bool _init)
                               "amd-smi metrics to collect: busy, temp, power, "
                               "vcn_activity, jpeg_activity, mem_usage. "
                               "An empty value implies 'all' and 'none' suppresses all.",
-                              "busy, temp, power, mem_usage",
-                              "backend", "amd_smi", "rocm", "process_sampling");
+                              "busy, temp, power, mem_usage", "backend", "amd_smi",
+                              "rocm", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB",
                               "Hint for shared-memory buffer size in perfetto (in KB)",

--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -629,10 +629,10 @@ configure_settings(bool _init)
 
     ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_AMD_SMI_METRICS",
                               "amd-smi metrics to collect: busy, temp, power, "
-                              "vcn_activity, jpeg_activity, mem_usage."
+                              "vcn_activity, jpeg_activity, mem_usage. "
                               "An empty value implies 'all' and 'none' suppresses all.",
-                              "busy, temp, power, mem_usage", "backend", "amd_smi",
-                              "rocm", "process_sampling", "advanced");
+                              "busy, temp, power, mem_usage, vcn_activity, jpeg_activity",
+                              "backend", "amd_smi", "rocm", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB",
                               "Hint for shared-memory buffer size in perfetto (in KB)",


### PR DESCRIPTION
Removed advanced category from ROCPROFSYS_AMD_SMI_METRICS and added vcn_activity, jpeg_activity to the options.

this change will make it available with **rocprof-sys-avail -S** command
Output:
|---------------------------------------|---------------------------------------------------------------------------------------|
|         ENVIRONMENT VARIABLE          |                                         VALUE                                         |
|---------------------------------------|---------------------------------------------------------------------------------------|
| ROCPROFSYS_AMD_SMI_METRICS            |               busy, temp, power, mem_usage, vcn_activity, jpeg_activity               |

it was earlier available with **rocprof-sys-avail --advanced** command
|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------|
|                         ENVIRONMENT VARIABLE                          |                                         VALUE                                         |
|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------|
| ROCPROFSYS_AMD_SMI_METRICS                                            |                             busy, temp, power, mem_usage                              |

