### PR TITLE
Add amd_smi activity to perfetto trace & sampling txt

### DIFF
--- a/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -38,9 +38,9 @@
 #include "core/gpu.hpp"
 #include "core/perfetto.hpp"
 #include "core/state.hpp"
+#include "library/components/backtrace.hpp"
 #include "library/runtime.hpp"
 #include "library/thread_info.hpp"
-#include "library/components/backtrace.hpp"
 
 #include <timemory/backends/threading.hpp>
 #include <timemory/components/timing/backends.hpp>
@@ -52,12 +52,12 @@
 #include <cassert>
 #include <chrono>
 #include <ios>
+#include <signal.h>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <sys/resource.h>
 #include <thread>
-#include <signal.h>
 
 #define ROCPROFSYS_AMD_SMI_CALL(...)                                                     \
     ::rocprofsys::amd_smi::check_error(__FILE__, __LINE__, __VA_ARGS__)
@@ -141,7 +141,7 @@ data::data(uint32_t _dev_id) { sample(_dev_id); }
 
 // Add atomic to store signo
 std::atomic<int> g_last_signo{ 0 };
-void 
+void
 signal_handler(int signo)
 {
     g_last_signo.store(signo, std::memory_order_relaxed);
@@ -464,10 +464,10 @@ data::post_process(uint32_t _dev_id)
             }
         }
 
-        using samp_bundle_t = 
+        using samp_bundle_t =
             tim::lightweight_tuple<sampling_gpu_busy_gfx, sampling_gpu_busy_umc,
-                                        sampling_gpu_busy_mm, sampling_gpu_temp,
-                                        sampling_gpu_power, sampling_gpu_memory>;
+                                   sampling_gpu_busy_mm, sampling_gpu_temp,
+                                   sampling_gpu_power, sampling_gpu_memory>;
 
         trait::runtime_enabled<sampling_gpu_busy_gfx>::set(_settings.busy);
         trait::runtime_enabled<sampling_gpu_busy_umc>::set(_settings.busy);
@@ -495,7 +495,7 @@ data::post_process(uint32_t _dev_id)
             for(const auto& s : itr.m_stack)
             {
                 std::string label  = s;
-                auto&   bundle     = bundle_v.emplace_back(label);
+                auto&       bundle = bundle_v.emplace_back(label);
                 bundle.push();
                 bundle.start();
                 bundle.stop();

--- a/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -140,8 +140,9 @@ std::unique_ptr<data::promise_t> data::polling_finished = {};
 data::data(uint32_t _dev_id) { sample(_dev_id); }
 
 // Add atomic to store signo
-std::atomic<int> g_last_signo{0};
-void signal_handler(int signo)
+std::atomic<int> g_last_signo{ 0 };
+void 
+signal_handler(int signo)
 {
     g_last_signo.store(signo, std::memory_order_relaxed);
 }
@@ -163,7 +164,7 @@ data::sample(uint32_t _dev_id)
     // Use the backtrace utility from library/components/backtrace.hpp
     signal(SIGUSR1, signal_handler);
     rocprofsys::component::backtrace bt;
-    bt.sample(g_last_signo.get());
+    bt.sample(g_last_signo.load());
     auto backtrace = bt.get();
     if(!backtrace.empty())
     {
@@ -311,7 +312,8 @@ data::shutdown()
     if constexpr(tim::trait::is_available<COMPONENT>::value)                             \
     {                                                                                    \
         auto* _val = BUNDLE.get<COMPONENT>();                                            \
-        if(_val) {                                                                      \
+        if(_val)                                                                         \
+        {                                                                                \
             _val->set_value(VAL);                                                        \
             _val->set_accum(TS);                                                         \
         }                                                                                \
@@ -462,7 +464,8 @@ data::post_process(uint32_t _dev_id)
             }
         }
 
-        using samp_bundle_t = tim::lightweight_tuple<sampling_gpu_busy_gfx, sampling_gpu_busy_umc,
+        using samp_bundle_t = 
+            tim::lightweight_tuple<sampling_gpu_busy_gfx, sampling_gpu_busy_umc,
                                         sampling_gpu_busy_mm, sampling_gpu_temp,
                                         sampling_gpu_power, sampling_gpu_memory>;
 
@@ -491,8 +494,8 @@ data::post_process(uint32_t _dev_id)
             bundle_v.reserve(itr.m_stack.size());
             for(const auto& s : itr.m_stack)
             {
-                std::string label = s;
-                auto& bundle = bundle_v.emplace_back(label);
+                std::string label  = s;
+                auto&   bundle     = bundle_v.emplace_back(label);
                 bundle.push();
                 bundle.start();
                 bundle.stop();
@@ -502,13 +505,16 @@ data::post_process(uint32_t _dev_id)
                     GPU_METRIC(sampling_gpu_busy_umc, bundle, _umcbusy, _ts, label);
                     GPU_METRIC(sampling_gpu_busy_mm, bundle, _mmbusy, _ts, label);
                 }
-                if(_settings.temp){
+                if(_settings.temp)
+                {
                     GPU_METRIC(sampling_gpu_temp, bundle, _temp, _ts, label);
                 }
-                if(_settings.power){
+                if(_settings.power)
+                {
                     GPU_METRIC(sampling_gpu_power, bundle, _power, _ts, label);
                 }
-                if(_settings.mem_usage){
+                if(_settings.mem_usage)
+                {
                     GPU_METRIC(sampling_gpu_memory, bundle, _usage, _ts, label);
                 }
                 bundle.pop();

--- a/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -156,21 +156,29 @@ data::sample(uint32_t _dev_id)
 
     void* callstack[16];
     int frames = backtrace(callstack, 16);
-    for(int i = 0; i < frames; ++i)
-    {
-        Dl_info info;
-        if(dladdr(callstack[i], &info) && info.dli_sname)
-        {
-            int status = 0;
-            char* demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
-            if(demangled && status == 0)
-                m_stack.push_back(std::string(demangled));
-            else
-                m_stack.push_back(std::string(info.dli_sname));
-            free(demangled);
+    char** symbols = backtrace_symbols(callstack, frames);
+    
+    if(symbols != nullptr) {
+        for(int i = 0; i < frames; ++i) {
+            std::string sym = symbols[i];
+            // Extract the mangled name from the backtrace symbol string
+            size_t start = sym.find('(');
+            size_t end = sym.find('+');
+            if(start != std::string::npos && end != std::string::npos) {
+                std::string mangled = sym.substr(start + 1, end - start - 1);
+                int status = 0;
+                char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
+                if(demangled && status == 0) {
+                    m_stack.push_back(std::string(demangled));
+                    free(demangled);
+                } else {
+                    m_stack.push_back(mangled);
+                }
+            } else {
+                m_stack.push_back(sym);
+            }
         }
-        else
-            m_stack.push_back("??");
+        free(symbols);
     }
 
 #define ROCPROFSYS_AMDSMI_GET(OPTION, FUNCTION, ...)                                     \
@@ -488,35 +496,30 @@ data::post_process(uint32_t _dev_id)
 
             std::vector<samp_bundle_t> bundle_v{};
             bundle_v.reserve(itr.m_stack.size());
-            std::string label = "??";
             for(const auto& s : itr.m_stack)
             {
-                if(s != "??")
+                std::string label = s;
+                auto& bundle = bundle_v.emplace_back(label);
+                bundle.push();
+                bundle.start();
+                bundle.stop();
+                if(_settings.busy)
                 {
-                    label = s;
-                    break;
+                    GPU_METRIC(sampling_gpu_busy_gfx, bundle, _gfxbusy, _ts, label);
+                    GPU_METRIC(sampling_gpu_busy_umc, bundle, _umcbusy, _ts, label);
+                    GPU_METRIC(sampling_gpu_busy_mm, bundle, _mmbusy, _ts, label);
                 }
+                if(_settings.temp){
+                    GPU_METRIC(sampling_gpu_temp, bundle, _temp, _ts, label);
+                }
+                if(_settings.power){
+                    GPU_METRIC(sampling_gpu_power, bundle, _power, _ts, label);
+                }
+                if(_settings.mem_usage){
+                    GPU_METRIC(sampling_gpu_memory, bundle, _usage, _ts, label);
+                }
+                bundle.pop();
             }
-
-            auto& bundle = bundle_v.emplace_back(label);
-            bundle.push();
-            bundle.start();
-            bundle.stop();
-            if(_settings.busy)
-            {
-                GPU_METRIC(sampling_gpu_busy_gfx, bundle, _gfxbusy, _ts);
-                GPU_METRIC(sampling_gpu_busy_umc, bundle, _umcbusy, _ts);
-                GPU_METRIC(sampling_gpu_busy_mm, bundle, _mmbusy, _ts);
-            }
-            if(_settings.temp){
-                GPU_METRIC(sampling_gpu_temp, bundle, _temp, _ts);            }
-            if(_settings.power){
-                GPU_METRIC(sampling_gpu_power, bundle, _power, _ts);
-            }
-            if(_settings.mem_usage){
-                GPU_METRIC(sampling_gpu_memory, bundle, _usage, _ts);
-            }
-            bundle.pop();
         }
     };
 

--- a/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -56,6 +56,9 @@
 #include <string>
 #include <sys/resource.h>
 #include <thread>
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <execinfo.h>
 
 #define ROCPROFSYS_AMD_SMI_CALL(...)                                                     \
     ::rocprofsys::amd_smi::check_error(__FILE__, __LINE__, __VA_ARGS__)
@@ -150,6 +153,25 @@ data::sample(uint32_t _dev_id)
 
     m_dev_id = _dev_id;
     m_ts     = _ts;
+
+    void* callstack[16];
+    int frames = backtrace(callstack, 16);
+    for(int i = 0; i < frames; ++i)
+    {
+        Dl_info info;
+        if(dladdr(callstack[i], &info) && info.dli_sname)
+        {
+            int status = 0;
+            char* demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
+            if(demangled && status == 0)
+                m_stack.push_back(std::string(demangled));
+            else
+                m_stack.push_back(std::string(info.dli_sname));
+            free(demangled);
+        }
+        else
+            m_stack.push_back("??");
+    }
 
 #define ROCPROFSYS_AMDSMI_GET(OPTION, FUNCTION, ...)                                     \
     if(OPTION)                                                                           \
@@ -284,14 +306,13 @@ data::shutdown()
     return true;
 }
 
-#define GPU_METRIC(COMPONENT, ...)                                                       \
+#define GPU_METRIC(COMPONENT, BUNDLE, VAL, TS, ...)                                      \
     if constexpr(tim::trait::is_available<COMPONENT>::value)                             \
     {                                                                                    \
-        auto* _val = _v.get<COMPONENT>();                                                \
-        if(_val)                                                                         \
-        {                                                                                \
-            _val->set_value(itr.__VA_ARGS__);                                            \
-            _val->set_accum(itr.__VA_ARGS__);                                            \
+        auto* _val = BUNDLE.get<COMPONENT>();                                            \
+        if(_val) {                                                                      \
+            _val->set_value(VAL);                                                        \
+            _val->set_accum(TS);                                                         \
         }                                                                                \
     }
 
@@ -438,6 +459,64 @@ data::post_process(uint32_t _dev_id)
                     ++idx;
                 }
             }
+        }
+
+        using samp_bundle_t = tim::lightweight_tuple<sampling_gpu_busy_gfx, sampling_gpu_busy_umc,
+                                        sampling_gpu_busy_mm, sampling_gpu_temp,
+                                        sampling_gpu_power, sampling_gpu_memory>;
+
+        trait::runtime_enabled<sampling_gpu_busy_gfx>::set(_settings.busy);
+        trait::runtime_enabled<sampling_gpu_busy_umc>::set(_settings.busy);
+        trait::runtime_enabled<sampling_gpu_busy_mm>::set(_settings.busy);
+        trait::runtime_enabled<sampling_gpu_temp>::set(_settings.temp);
+        trait::runtime_enabled<sampling_gpu_power>::set(_settings.power);
+        trait::runtime_enabled<sampling_gpu_memory>::set(_settings.mem_usage);
+
+        for(auto& itr : _amd_smi)
+        {
+            if(itr.m_dev_id != _dev_id) continue;
+
+            uint64_t _ts = itr.m_ts;
+            if(!_thread_info->is_valid_time(_ts)) continue;
+
+            double _gfxbusy = itr.m_busy_perc.gfx_activity;
+            double _umcbusy = itr.m_busy_perc.umc_activity;
+            double _mmbusy  = itr.m_busy_perc.mm_activity;
+            double _temp    = itr.m_temp;
+            double _power   = itr.m_power.current_socket_power;
+            double _usage   = itr.m_mem_usage / static_cast<double>(units::megabyte);
+
+            std::vector<samp_bundle_t> bundle_v{};
+            bundle_v.reserve(itr.m_stack.size());
+            std::string label = "??";
+            for(const auto& s : itr.m_stack)
+            {
+                if(s != "??")
+                {
+                    label = s;
+                    break;
+                }
+            }
+
+            auto& bundle = bundle_v.emplace_back(label);
+            bundle.push();
+            bundle.start();
+            bundle.stop();
+            if(_settings.busy)
+            {
+                GPU_METRIC(sampling_gpu_busy_gfx, bundle, _gfxbusy, _ts);
+                GPU_METRIC(sampling_gpu_busy_umc, bundle, _umcbusy, _ts);
+                GPU_METRIC(sampling_gpu_busy_mm, bundle, _mmbusy, _ts);
+            }
+            if(_settings.temp){
+                GPU_METRIC(sampling_gpu_temp, bundle, _temp, _ts);            }
+            if(_settings.power){
+                GPU_METRIC(sampling_gpu_power, bundle, _power, _ts);
+            }
+            if(_settings.mem_usage){
+                GPU_METRIC(sampling_gpu_memory, bundle, _usage, _ts);
+            }
+            bundle.pop();
         }
     };
 

--- a/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -40,6 +40,7 @@
 #include "core/state.hpp"
 #include "library/runtime.hpp"
 #include "library/thread_info.hpp"
+#include "library/components/backtrace.hpp"
 
 #include <timemory/backends/threading.hpp>
 #include <timemory/components/timing/backends.hpp>
@@ -56,9 +57,7 @@
 #include <string>
 #include <sys/resource.h>
 #include <thread>
-#include <cxxabi.h>
-#include <dlfcn.h>
-#include <execinfo.h>
+#include <signal.h>
 
 #define ROCPROFSYS_AMD_SMI_CALL(...)                                                     \
     ::rocprofsys::amd_smi::check_error(__FILE__, __LINE__, __VA_ARGS__)
@@ -140,6 +139,13 @@ std::unique_ptr<data::promise_t> data::polling_finished = {};
 
 data::data(uint32_t _dev_id) { sample(_dev_id); }
 
+// Add atomic to store signo
+std::atomic<int> g_last_signo{0};
+void signal_handler(int signo)
+{
+    g_last_signo.store(signo, std::memory_order_relaxed);
+}
+
 void
 data::sample(uint32_t _dev_id)
 {
@@ -154,31 +160,18 @@ data::sample(uint32_t _dev_id)
     m_dev_id = _dev_id;
     m_ts     = _ts;
 
-    void* callstack[16];
-    int frames = backtrace(callstack, 16);
-    char** symbols = backtrace_symbols(callstack, frames);
-    
-    if(symbols != nullptr) {
-        for(int i = 0; i < frames; ++i) {
-            std::string sym = symbols[i];
-            // Extract the mangled name from the backtrace symbol string
-            size_t start = sym.find('(');
-            size_t end = sym.find('+');
-            if(start != std::string::npos && end != std::string::npos) {
-                std::string mangled = sym.substr(start + 1, end - start - 1);
-                int status = 0;
-                char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
-                if(demangled && status == 0) {
-                    m_stack.push_back(std::string(demangled));
-                    free(demangled);
-                } else {
-                    m_stack.push_back(mangled);
-                }
-            } else {
-                m_stack.push_back(sym);
-            }
+    // Use the backtrace utility from library/components/backtrace.hpp
+    signal(SIGUSR1, signal_handler);
+    rocprofsys::component::backtrace bt;
+    bt.sample(g_last_signo.get());
+    auto backtrace = bt.get();
+    if(!backtrace.empty())
+    {
+        m_stack.reserve(backtrace.size());
+        for(const auto& itr : backtrace)
+        {
+            m_stack.push_back(itr.name);
         }
-        free(symbols);
     }
 
 #define ROCPROFSYS_AMDSMI_GET(OPTION, FUNCTION, ...)                                     \

--- a/source/lib/rocprof-sys/library/amd_smi.hpp
+++ b/source/lib/rocprof-sys/library/amd_smi.hpp
@@ -48,6 +48,7 @@
 #include <thread>
 #include <tuple>
 #include <type_traits>
+#include <string>
 
 namespace rocprofsys
 {
@@ -108,6 +109,7 @@ struct data
     mem_usage_t           m_mem_usage    = 0;
     std::vector<uint16_t> m_vcn_metrics  = {};
     std::vector<uint16_t> m_jpeg_metrics = {};
+    std::vector<std::string> m_stack = {};
 #if ROCPROFSYS_USE_ROCM > 0
     amdsmi_engine_usage_t m_busy_perc = {};
     amdsmi_power_info_t   m_power     = {};

--- a/source/lib/rocprof-sys/library/amd_smi.hpp
+++ b/source/lib/rocprof-sys/library/amd_smi.hpp
@@ -103,13 +103,13 @@ struct data
 
     static void post_process(uint32_t _dev_id);
 
-    uint32_t              m_dev_id       = std::numeric_limits<uint32_t>::max();
-    timestamp_t           m_ts           = 0;
-    temp_t                m_temp         = 0;
-    mem_usage_t           m_mem_usage    = 0;
-    std::vector<uint16_t> m_vcn_metrics  = {};
-    std::vector<uint16_t> m_jpeg_metrics = {};
-    std::vector<std::string> m_stack     = {};
+    uint32_t                 m_dev_id       = std::numeric_limits<uint32_t>::max();
+    timestamp_t              m_ts           = 0;
+    temp_t                   m_temp         = 0;
+    mem_usage_t              m_mem_usage    = 0;
+    std::vector<uint16_t>    m_vcn_metrics  = {};
+    std::vector<uint16_t>    m_jpeg_metrics = {};
+    std::vector<std::string> m_stack        = {};
 #if ROCPROFSYS_USE_ROCM > 0
     amdsmi_engine_usage_t m_busy_perc = {};
     amdsmi_power_info_t   m_power     = {};

--- a/source/lib/rocprof-sys/library/amd_smi.hpp
+++ b/source/lib/rocprof-sys/library/amd_smi.hpp
@@ -45,10 +45,10 @@
 #include <limits>
 #include <memory>
 #include <ratio>
+#include <string>
 #include <thread>
 #include <tuple>
 #include <type_traits>
-#include <string>
 
 namespace rocprofsys
 {
@@ -109,7 +109,7 @@ struct data
     mem_usage_t           m_mem_usage    = 0;
     std::vector<uint16_t> m_vcn_metrics  = {};
     std::vector<uint16_t> m_jpeg_metrics = {};
-    std::vector<std::string> m_stack = {};
+    std::vector<std::string> m_stack     = {};
 #if ROCPROFSYS_USE_ROCM > 0
     amdsmi_engine_usage_t m_busy_perc = {};
     amdsmi_power_info_t   m_power     = {};


### PR DESCRIPTION
Generation of sampling_gpu_busy*, sampling_gpu_power, sampling_gpu_temperature, sampling_gpu_memory_usage files.