### PR TITLE
add CODEOWNERS for docs/sphinx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,8 @@
 * @ROCm/rocprof-sys @jrmadsen 
 
 # Documentation files
-docs/* @ROCm/rocm-documentation
+docs/** @ROCm/rocm-documentation
 *.md @ROCm/rocm-documentation
 *.rst @ROCm/rocm-documentation
 .readthedocs.yaml @ROCm/rocm-documentation
+docs/sphinx/* @samjwu


### PR DESCRIPTION
[WHY]
Reviewers field in dependabot file is being deprecated.

For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).