### PR TITLE
Improve rocprof-sys-avail to report VCN and JPEG metrics on supported devices

### DIFF
--- a/source/lib/core/CMakeLists.txt
+++ b/source/lib/core/CMakeLists.txt
@@ -15,6 +15,7 @@ set(core_sources
     ${CMAKE_CURRENT_LIST_DIR}/perf.cpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rocprofiler-sdk.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/amd_smi.cpp
     ${CMAKE_CURRENT_LIST_DIR}/state.cpp
     ${CMAKE_CURRENT_LIST_DIR}/timemory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/utility.cpp)
@@ -37,6 +38,7 @@ set(core_headers
     ${CMAKE_CURRENT_LIST_DIR}/rccl.hpp
     ${CMAKE_CURRENT_LIST_DIR}/redirect.hpp
     ${CMAKE_CURRENT_LIST_DIR}/rocprofiler-sdk.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/amd_smi.hpp
     ${CMAKE_CURRENT_LIST_DIR}/state.hpp
     ${CMAKE_CURRENT_LIST_DIR}/timemory.hpp
     ${CMAKE_CURRENT_LIST_DIR}/utility.hpp)

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -26,15 +26,10 @@
 #include "core/debug.hpp"
 #include "core/gpu.hpp"
 #include "timemory.hpp"
-#include <cassert>
 #include <chrono>
-#include <ios>
-#include <regex>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <sys/resource.h>
-#include <thread>
 
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 namespace rocprofsys
@@ -70,16 +65,14 @@ get_setting_name(std::string _v)
         }()
 }  // namespace
 
-// See hpp for more information
-std::unordered_set<uint32_t> amd_smi_config_data::gpuID_vcn_support  = {};
-std::unordered_set<uint32_t> amd_smi_config_data::gpuID_jpeg_support = {};
+std::set<uint32_t> amd_smi_config_data::gpuID_vcn_support  = {};
+std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_support = {};
 
 bool
 setup_config_check()
 {
     if(!get_use_amd_smi() || !gpu::initialize_amdsmi()) return false;
 
-    // Get processors and activity support
     size_t device_count = gpu::get_processor_count();
     for(size_t i = 0; i < device_count; i++)
     {

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -31,7 +31,6 @@
 #include <string>
 #include <sys/resource.h>
 
-
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 namespace rocprofsys
 {
@@ -79,16 +78,6 @@ setup_config_check()
     size_t device_count = gpu::get_processor_count();
     for(size_t i = 0; i < device_count; i++)
     {
-        // if(gpu::is_jpeg_activity_supported(i))
-        //     amd_smi_config_data::gpuID_jpeg_activity_support.insert(i);
-        // else if(gpu::is_jpeg_busy_supported(i))
-        //     amd_smi_config_data::gpuID_jpeg_busy_support.insert(i);
-
-        // if(gpu::is_vcn_activity_supported(i))
-        //     amd_smi_config_data::gpuID_vcn_activity_support.insert(i);
-        // else if(gpu::is_vcn_busy_supported(i))
-        //     amd_smi_config_data::gpuID_vcn_busy_support.insert(i);
-
         if(gpu::is_vcn_activity_supported(i) || gpu::is_vcn_busy_supported(i))
             amd_smi_config_data::gpuID_vcn_activity_support.insert(i);
         if(gpu::is_jpeg_activity_supported(i) || gpu::is_jpeg_busy_supported(i))
@@ -104,56 +93,25 @@ config_settings(const std::shared_ptr<settings>& _config)
 
     std::string default_metrics = "busy, temp, power, mem_usage";
     // List of gpu's that support JPEG and VCN activity
-    // As of now, no distinction between busy and activity shown in description
+    // No distinction between busy and activity shown in description
     std::string jpeg_activity_support = "";
-    // std::string jpeg_busy_support     = "";
     std::string vcn_activity_support  = "";
-    // std::string vcn_busy_support      = "";
 
     if(!amd_smi_config_data::gpuID_jpeg_activity_support.empty())
     {
-        // jpeg_activity_support += ", jpeg_activity (GPUs:";
-        // for(const auto& id : amd_smi_config_data::gpuID_jpeg_activity_support)
-        //     jpeg_activity_support += " " + std::to_string(id) + ",";
-        // jpeg_activity_support.pop_back();
-        // jpeg_activity_support += ")";
         jpeg_activity_support += ", jpeg_activity";
     }
 
-    // if(!amd_smi_config_data::gpuID_jpeg_busy_support.empty())
-    // {
-    //     jpeg_busy_support += ", jpeg_busy (GPUs:";
-    //     for(const auto& id : amd_smi_config_data::gpuID_jpeg_busy_support)
-    //         jpeg_busy_support += " " + std::to_string(id) + ",";
-    //     jpeg_busy_support.pop_back();
-    //     jpeg_busy_support += ")";
-    // }
-
     if(!amd_smi_config_data::gpuID_vcn_activity_support.empty())
     {
-        // vcn_activity_support += ", vcn_activity (GPUs:";
-        // for(const auto& id : amd_smi_config_data::gpuID_vcn_activity_support)
-        //     vcn_activity_support += " " + std::to_string(id) + ",";
-        // vcn_activity_support.pop_back();
-        // vcn_activity_support += ")";
         vcn_activity_support += ", vcn_activity";
     }
 
-    // if(!amd_smi_config_data::gpuID_vcn_busy_support.empty())
-    // {
-    //     vcn_busy_support += ", vcn_busy (GPUs:";
-    //     for(const auto& id : amd_smi_config_data::gpuID_vcn_busy_support)
-    //         vcn_busy_support += " " + std::to_string(id) + ",";
-    //     vcn_busy_support.pop_back();
-    //     vcn_busy_support += ")";
-    // }
-
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_AMD_SMI_METRICS",
-        "amd-smi metrics to collect: " + default_metrics + 
-         jpeg_activity_support + vcn_activity_support + 
-    //     jpeg_busy_support + vcn_busy_support + 
-         ". " + "An empty value implies 'all' and 'none' suppresses all.",
+        "amd-smi metrics to collect: " + default_metrics + jpeg_activity_support +
+            vcn_activity_support + ". " +
+            "An empty value implies 'all' and 'none' suppresses all.",
         "busy, temp, power, mem_usage", "backend", "amd_smi", "rocm", "process_sampling");
 }
 }  // namespace amd_smi

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -36,9 +36,6 @@
 #include <sys/resource.h>
 #include <thread>
 
-#define ROCPROFSYS_AMD_SMI_CALL(...)                                                     \
-    ::rocprofsys::amd_smi::check_error(__FILE__, __LINE__, __VA_ARGS__)
-
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 namespace rocprofsys
 {
@@ -46,13 +43,6 @@ namespace amd_smi
 {
 namespace
 {
-auto&
-get_settings(uint32_t _dev_id)
-{
-    static auto _v = std::unordered_map<uint32_t, amd_smi_settings>{};
-    return _v[_dev_id];
-}
-
 std::string
 get_setting_name(std::string _v)
 {
@@ -62,28 +52,6 @@ get_setting_name(std::string _v)
     auto _pos = _v.find(_prefix);
     if(_pos == 0) return _v.substr(_prefix.length());
     return _v;
-}
-
-void
-check_error(const char* _file, int _line, amdsmi_status_t _code, bool* _option = nullptr)
-{
-    if(_code == AMDSMI_STATUS_SUCCESS)
-        return;
-    else if(_code == AMDSMI_STATUS_NOT_SUPPORTED && _option)
-    {
-        *_option = false;
-        return;
-    }
-
-    const char* _msg = nullptr;
-    auto        _err = amdsmi_status_code_to_string(_code, &_msg);
-    if(_err != AMDSMI_STATUS_SUCCESS)
-        ROCPROFSYS_THROW(
-            "amdsmi_status_code_to_string failed. No error message available. "
-            "Error code %i originated at %s:%i\n",
-            static_cast<int>(_code), _file, _line);
-    ROCPROFSYS_THROW("[%s:%i] Error code %i :: %s", _file, _line, static_cast<int>(_code),
-                     _msg);
 }
 
 #    define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)   \
@@ -102,132 +70,60 @@ check_error(const char* _file, int _line, amdsmi_status_t _code, bool* _option =
         }()
 }  // namespace
 
-std::set<uint32_t> amd_smi_config_data::device_list         = {};
-size_t             amd_smi_config_data::device_count        = 0;
-bool               amd_smi_config_data::track_jpeg_activity = false;
-bool               amd_smi_config_data::track_vcn_activity  = false;
+// See hpp for more information
+std::unordered_map<uint32_t> amd_smi_config_data::gpuID_vcn_support  = {};
+std::unordered_map<uint32_t> amd_smi_config_data::gpuID_jpeg_support = {};
 
-void
+bool
 setup_config_check()
 {
-    if(!get_use_amd_smi() || !gpu::initialize_amdsmi())
-    {
-        ROCPROFSYS_WARNING_F(
-            0, "AMD SMI is not available. Disabling jpeg and vcn activity tracking.");
-        return;
-    }
-    // Get processors and handles
-    amd_smi_config_data::device_count = gpu::get_processor_count();
-    auto _devices_v                   = get_sampling_gpus();
-    for(auto& itr : _devices_v)
-        itr = tolower(itr);
-    if(_devices_v == "off")
-        _devices_v = "none";
-    else if(_devices_v == "on")
-        _devices_v = "all";
-    bool _all_devices = _devices_v.find("all") != std::string::npos || _devices_v.empty();
-    bool _no_devices  = _devices_v.find("none") != std::string::npos;
+    if(!get_use_amd_smi() || !gpu::initialize_amdsmi()) return false;
 
-    std::set<uint32_t> _devices = {};
-    auto               _emplace = [&_devices](auto idx) {
-        if(idx < amd_smi_config_data::device_count) _devices.emplace(idx);
-    };
-
-    // Add devices to be sampled
-    if(_all_devices)
+    // Get processors and activity support
+    size_t device_count = gpu::get_processor_count();
+    for(size_t i = 0; i < amd_smi_config_data::device_count; i++)
     {
-        for(uint32_t i = 0; i < amd_smi_config_data::device_count; ++i)
-            _emplace(i);
+        if(gpu::is_jpeg_activity_supported(i) || gpu::is_jpeg_busy_supported(i))
+            amd_smi_config_data::gpuID_jpeg_support.insert(i);
+        if(gpu::is_vcn_activity_supported(i) || gpu::is_vcn_busy_supported(i))
+            amd_smi_config_data::gpuID_vcn_support.insert(i);
     }
-    else if(!_no_devices)
-    {
-        auto _enabled = tim::delimit(_devices_v, ",; \t");
-        for(auto&& itr : _enabled)
-        {
-            if(itr.find_first_not_of("0123456789-") != std::string::npos)
-            {
-                ROCPROFSYS_THROW("Invalid GPU specification: '%s'. Only numerical values "
-                                 "(e.g., 0) or ranges (e.g., 0-7) are permitted.",
-                                 itr.c_str());
-            }
-
-            if(itr.find('-') != std::string::npos)
-            {
-                auto _v = tim::delimit(itr, "-");
-                ROCPROFSYS_CONDITIONAL_THROW(_v.size() != 2,
-                                             "Invalid GPU range specification: '%s'. "
-                                             "Required format N-M, e.g. 0-4",
-                                             itr.c_str());
-                for(auto i = std::stoul(_v.at(0)); i < std::stoul(_v.at(1)); ++i)
-                    _emplace(i);
-            }
-            else
-            {
-                _emplace(std::stoul(itr));
-            }
-        }
-    }
-    else if(_no_devices)
-    {
-        ROCPROFSYS_WARNING_F(0, "No AMD SMI devices specified. Disabling AMD SMI "
-                                "sampling for all devices...");
-        return;
-    }
-    // Set Device list
-    amd_smi_config_data::device_list = _devices;
+    return true;
 }
 
 void
 config_settings(const std::shared_ptr<settings>& _config)
 {
-    setup_config_check();
-    std::string desc_metrics = "busy, temp, power, mem_usage";
+    if(!setup_config_check()) return;
 
-#    define ROCPROFSYS_AMDSMI_GET(OPTION, FUNCTION, ...)                                 \
-        if(OPTION)                                                                       \
-        {                                                                                \
-            try                                                                          \
-            {                                                                            \
-                ROCPROFSYS_AMD_SMI_CALL(FUNCTION(__VA_ARGS__), &OPTION);                 \
-            } catch(std::runtime_error & _e)                                             \
-            {                                                                            \
-                ROCPROFSYS_VERBOSE_F(                                                    \
-                    0, "[%s] Exception: %s. Disabling future samples from amd-smi...\n", \
-                    #FUNCTION, _e.what());                                               \
-            }                                                                            \
-        }
+    std::string default_metrics = "busy, temp, power, mem_usage";
+    // List of gpu's that support JPEG and VCN activity
+    // As of now, no distinction between busy and activity shown in description
+    std::string jpeg_support = "";
+    std::string vcn_support  = "";
 
-    if(!amd_smi_config_data::device_list.empty())
+    if(!gpuID_jpeg_support.empty())
     {
-        for(const auto& dev_id : amd_smi_config_data::device_list)
-        {
-            amdsmi_gpu_metrics_t    _gpu_metrics{};
-            amdsmi_processor_handle sample_handle = gpu::get_handle_from_id(dev_id);
-
-            // Verify that metrics are available and set respective flag
-            ROCPROFSYS_AMDSMI_GET(get_settings(dev_id).vcn_activity,
-                                  amdsmi_get_gpu_metrics_info, sample_handle,
-                                  &_gpu_metrics);
-            ROCPROFSYS_AMDSMI_GET(get_settings(dev_id).jpeg_activity,
-                                  amdsmi_get_gpu_metrics_info, sample_handle,
-                                  &_gpu_metrics);
-
-            if(_gpu_metrics.vcn_activity[0] != UINT16_MAX)
-                amd_smi_config_data::track_vcn_activity = true;
-            if(_gpu_metrics.jpeg_activity[0] != UINT16_MAX)
-                amd_smi_config_data::track_jpeg_activity = true;
-        }
-#    undef ROCPROFSYS_AMDSMI_GET
+        jpeg_support += ", jpeg_activity (GPUs:";
+        for(const auto& id : amd_smi_config_data::gpuID_jpeg_support)
+            jpeg_support += " " + std::to_string(id) + ",";
+        jpeg_support.pop_back();
+        jpeg_support += ")";
     }
 
-    if(amd_smi_config_data::track_jpeg_activity) desc_metrics += ", jpeg_activity";
-    if(amd_smi_config_data::track_vcn_activity) desc_metrics += ", vcn_activity";
+    if(!gpuID_vcn_support.empty())
+    {
+        vcn_support += ", vcn_activity (GPUs:";
+        for(const auto& id : amd_smi_config_data::gpuID_vcn_support)
+            vcn_support += " " + std::to_string(id) + ",";
+        vcn_support.pop_back();
+        vcn_support += ")";
+    }
 
-    desc_metrics += ". ";
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_AMD_SMI_METRICS",
-        "amd-smi metrics to collect: " + desc_metrics +
-            "An empty value implies 'all' and 'none' suppresses all.",
+        "amd-smi metrics to collect: " + desc_metrics + jpeg_support + vcn_support +
+            ". " + "An empty value implies 'all' and 'none' suppresses all.",
         "busy, temp, power, mem_usage", "backend", "amd_smi", "rocm", "process_sampling");
 }
 }  // namespace amd_smi

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -105,6 +105,7 @@ check_error(const char* _file, int _line, amdsmi_status_t _code, bool* _option =
 std::set<uint32_t> amd_smi_config_data::device_list         = {};
 size_t             amd_smi_config_data::device_count        = 0;
 bool               amd_smi_config_data::track_jpeg_activity = false;
+bool               amd_smi_config_data::track_vcn_activity  = false;
 
 void
 setup_config_check()
@@ -112,7 +113,7 @@ setup_config_check()
     if(!get_use_amd_smi() || !gpu::initialize_amdsmi())
     {
         ROCPROFSYS_WARNING_F(
-            0, "AMD SMI is not available. Disabling jpeg activity tracking.");
+            0, "AMD SMI is not available. Disabling jpeg and vcn activity tracking.");
         return;
     }
     // Get processors and handles
@@ -132,7 +133,7 @@ setup_config_check()
         if(idx < amd_smi_config_data::device_count) _devices.emplace(idx);
     };
 
-    // Add devices to be sampled (to read jpeg_activity)
+    // Add devices to be sampled
     if(_all_devices)
     {
         for(uint32_t i = 0; i < amd_smi_config_data::device_count; ++i)
@@ -180,7 +181,7 @@ void
 config_settings(const std::shared_ptr<settings>& _config)
 {
     setup_config_check();
-    std::string desc_metrics = "busy, temp, power, mem_usage, vcn_metrics";
+    std::string desc_metrics = "busy, temp, power, mem_usage";
 
 #    define ROCPROFSYS_AMDSMI_GET(OPTION, FUNCTION, ...)                                 \
         if(OPTION)                                                                       \
@@ -196,7 +197,6 @@ config_settings(const std::shared_ptr<settings>& _config)
             }                                                                            \
         }
 
-    // Sample jpeg metric for availability
     if(!amd_smi_config_data::device_list.empty())
     {
         for(const auto& dev_id : amd_smi_config_data::device_list)
@@ -205,25 +205,23 @@ config_settings(const std::shared_ptr<settings>& _config)
             amdsmi_processor_handle sample_handle = gpu::get_handle_from_id(dev_id);
 
             // Verify that metrics are available and set respective flag
+            ROCPROFSYS_AMDSMI_GET(get_settings(dev_id).vcn_activity,
+                                  amdsmi_get_gpu_metrics_info, sample_handle,
+                                  &_gpu_metrics);
             ROCPROFSYS_AMDSMI_GET(get_settings(dev_id).jpeg_activity,
                                   amdsmi_get_gpu_metrics_info, sample_handle,
                                   &_gpu_metrics);
 
-            for(const auto& j_activity : _gpu_metrics.jpeg_activity)
-            {
-                if(j_activity != UINT16_MAX)
-                {
-                    amd_smi_config_data::track_jpeg_activity = true;
-                    break;
-                }
-            }
-
-            if(amd_smi_config_data::track_jpeg_activity) break;
+            if(_gpu_metrics.vcn_activity[0] != UINT16_MAX)
+                amd_smi_config_data::track_vcn_activity = true;
+            if(_gpu_metrics.jpeg_activity[0] != UINT16_MAX)
+                amd_smi_config_data::track_jpeg_activity = true;
         }
 #    undef ROCPROFSYS_AMDSMI_GET
     }
 
     if(amd_smi_config_data::track_jpeg_activity) desc_metrics += ", jpeg_activity";
+    if(amd_smi_config_data::track_vcn_activity) desc_metrics += ", vcn_activity";
 
     desc_metrics += ". ";
     ROCPROFSYS_CONFIG_SETTING(

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -26,10 +26,6 @@
 #include "core/debug.hpp"
 #include "core/gpu.hpp"
 #include "timemory.hpp"
-#include <chrono>
-#include <stdexcept>
-#include <string>
-#include <sys/resource.h>
 
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 namespace rocprofsys

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -1,0 +1,248 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "core/amd_smi.hpp"
+#include "core/common.hpp"
+#include "core/config.hpp"
+#include "core/debug.hpp"
+#include "core/gpu.hpp"
+#include "timemory.hpp"
+#include <cassert>
+#include <chrono>
+#include <ios>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <sys/resource.h>
+#include <thread>
+
+#define ROCPROFSYS_AMD_SMI_CALL(...)                                                     \
+    ::rocprofsys::amd_smi::check_error(__FILE__, __LINE__, __VA_ARGS__)
+
+#if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
+namespace rocprofsys
+{
+namespace amd_smi
+{
+namespace
+{
+auto&
+get_settings(uint32_t _dev_id)
+{
+    static auto _v = std::unordered_map<uint32_t, amd_smi_settings>{};
+    return _v[_dev_id];
+}
+
+std::string
+get_setting_name(std::string _v)
+{
+    constexpr auto _prefix = tim::string_view_t{ "rocprofsys_" };
+    for(auto& itr : _v)
+        itr = tolower(itr);
+    auto _pos = _v.find(_prefix);
+    if(_pos == 0) return _v.substr(_prefix.length());
+    return _v;
+}
+
+void
+check_error(const char* _file, int _line, amdsmi_status_t _code, bool* _option = nullptr)
+{
+    if(_code == AMDSMI_STATUS_SUCCESS)
+        return;
+    else if(_code == AMDSMI_STATUS_NOT_SUPPORTED && _option)
+    {
+        *_option = false;
+        return;
+    }
+
+    const char* _msg = nullptr;
+    auto        _err = amdsmi_status_code_to_string(_code, &_msg);
+    if(_err != AMDSMI_STATUS_SUCCESS)
+        ROCPROFSYS_THROW(
+            "amdsmi_status_code_to_string failed. No error message available. "
+            "Error code %i originated at %s:%i\n",
+            static_cast<int>(_code), _file, _line);
+    ROCPROFSYS_THROW("[%s:%i] Error code %i :: %s", _file, _line, static_cast<int>(_code),
+                     _msg);
+}
+
+#    define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)   \
+        [&]() {                                                                          \
+            auto _ret = _config->insert<TYPE, TYPE>(                                     \
+                ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION,                       \
+                TYPE{ INITIAL_VALUE },                                                   \
+                std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",         \
+                                       __VA_ARGS__ });                                   \
+            if(!_ret.second)                                                             \
+            {                                                                            \
+                ROCPROFSYS_PRINT("Warning! Duplicate setting: %s / %s\n",                \
+                                 get_setting_name(ENV_NAME).c_str(), ENV_NAME);          \
+            }                                                                            \
+            return _config->find(ENV_NAME)->second;                                      \
+        }()
+}  // namespace
+
+std::set<uint32_t> amd_smi_config_data::device_list         = {};
+size_t             amd_smi_config_data::device_count        = 0;
+bool               amd_smi_config_data::track_jpeg_activity = false;
+
+void
+setup_config_check()
+{
+    if(!get_use_amd_smi() || !gpu::initialize_amdsmi())
+    {
+        ROCPROFSYS_WARNING_F(
+            0, "AMD SMI is not available. Disabling jpeg activity tracking.");
+        return;
+    }
+    // Get processors and handles
+    amd_smi_config_data::device_count = gpu::get_processor_count();
+    auto _devices_v                   = get_sampling_gpus();
+    for(auto& itr : _devices_v)
+        itr = tolower(itr);
+    if(_devices_v == "off")
+        _devices_v = "none";
+    else if(_devices_v == "on")
+        _devices_v = "all";
+    bool _all_devices = _devices_v.find("all") != std::string::npos || _devices_v.empty();
+    bool _no_devices  = _devices_v.find("none") != std::string::npos;
+
+    std::set<uint32_t> _devices = {};
+    auto               _emplace = [&_devices](auto idx) {
+        if(idx < amd_smi_config_data::device_count) _devices.emplace(idx);
+    };
+
+    // Add devices to be sampled (to read jpeg_activity)
+    if(_all_devices)
+    {
+        for(uint32_t i = 0; i < amd_smi_config_data::device_count; ++i)
+            _emplace(i);
+    }
+    else if(!_no_devices)
+    {
+        auto _enabled = tim::delimit(_devices_v, ",; \t");
+        for(auto&& itr : _enabled)
+        {
+            if(itr.find_first_not_of("0123456789-") != std::string::npos)
+            {
+                ROCPROFSYS_THROW("Invalid GPU specification: '%s'. Only numerical values "
+                                 "(e.g., 0) or ranges (e.g., 0-7) are permitted.",
+                                 itr.c_str());
+            }
+
+            if(itr.find('-') != std::string::npos)
+            {
+                auto _v = tim::delimit(itr, "-");
+                ROCPROFSYS_CONDITIONAL_THROW(_v.size() != 2,
+                                             "Invalid GPU range specification: '%s'. "
+                                             "Required format N-M, e.g. 0-4",
+                                             itr.c_str());
+                for(auto i = std::stoul(_v.at(0)); i < std::stoul(_v.at(1)); ++i)
+                    _emplace(i);
+            }
+            else
+            {
+                _emplace(std::stoul(itr));
+            }
+        }
+    }
+    else if(_no_devices)
+    {
+        ROCPROFSYS_WARNING_F(0, "No AMD SMI devices specified. Disabling AMD SMI "
+                                "sampling for all devices...");
+        return;
+    }
+    // Set Device list
+    amd_smi_config_data::device_list = _devices;
+}
+
+void
+config_settings(const std::shared_ptr<settings>& _config)
+{
+    setup_config_check();
+    std::string desc_metrics = "busy, temp, power, mem_usage, vcn_metrics";
+
+#    define ROCPROFSYS_AMDSMI_GET(OPTION, FUNCTION, ...)                                 \
+        if(OPTION)                                                                       \
+        {                                                                                \
+            try                                                                          \
+            {                                                                            \
+                ROCPROFSYS_AMD_SMI_CALL(FUNCTION(__VA_ARGS__), &OPTION);                 \
+            } catch(std::runtime_error & _e)                                             \
+            {                                                                            \
+                ROCPROFSYS_VERBOSE_F(                                                    \
+                    0, "[%s] Exception: %s. Disabling future samples from amd-smi...\n", \
+                    #FUNCTION, _e.what());                                               \
+            }                                                                            \
+        }
+
+    // Sample jpeg metric for availability
+    if(!amd_smi_config_data::device_list.empty())
+    {
+        for(const auto& dev_id : amd_smi_config_data::device_list)
+        {
+            amdsmi_gpu_metrics_t    _gpu_metrics{};
+            amdsmi_processor_handle sample_handle = gpu::get_handle_from_id(dev_id);
+
+            // Verify that metrics are available and set respective flag
+            ROCPROFSYS_AMDSMI_GET(get_settings(dev_id).jpeg_activity,
+                                  amdsmi_get_gpu_metrics_info, sample_handle,
+                                  &_gpu_metrics);
+
+            for(const auto& j_activity : _gpu_metrics.jpeg_activity)
+            {
+                if(j_activity != UINT16_MAX)
+                {
+                    amd_smi_config_data::track_jpeg_activity = true;
+                    break;
+                }
+            }
+
+            if(amd_smi_config_data::track_jpeg_activity) break;
+        }
+#    undef ROCPROFSYS_AMDSMI_GET
+    }
+
+    if(amd_smi_config_data::track_jpeg_activity) desc_metrics += ", jpeg_activity";
+
+    desc_metrics += ". ";
+    ROCPROFSYS_CONFIG_SETTING(
+        std::string, "ROCPROFSYS_AMD_SMI_METRICS",
+        "amd-smi metrics to collect: " + desc_metrics +
+            "An empty value implies 'all' and 'none' suppresses all.",
+        "busy, temp, power, mem_usage", "backend", "amd_smi", "rocm", "process_sampling");
+}
+}  // namespace amd_smi
+}  // namespace rocprofsys
+
+#else
+namespace rocprofsys
+{
+namespace amd_smi
+{
+void
+config_settings(const std::shared_ptr<settings>&)
+{}
+}  // namespace amd_smi
+}  // namespace rocprofsys
+#endif

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -31,6 +31,8 @@
 #include <string>
 #include <sys/resource.h>
 
+#define ROCPROFSYS_USE_ROCM 1
+
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 namespace rocprofsys
 {
@@ -65,8 +67,10 @@ get_setting_name(std::string _v)
         }()
 }  // namespace
 
-std::set<uint32_t> amd_smi_config_data::gpuID_vcn_support  = {};
-std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_support = {};
+std::set<uint32_t> amd_smi_config_data::gpuID_vcn_activity_support  = {};
+std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_activity_support = {};
+std::set<uint32_t> amd_smi_config_data::gpuID_vcn_busy_support      = {};
+std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_busy_support     = {};
 
 bool
 setup_config_check()
@@ -76,10 +80,15 @@ setup_config_check()
     size_t device_count = gpu::get_processor_count();
     for(size_t i = 0; i < device_count; i++)
     {
-        if(gpu::is_jpeg_activity_supported(i) || gpu::is_jpeg_busy_supported(i))
-            amd_smi_config_data::gpuID_jpeg_support.insert(i);
-        if(gpu::is_vcn_activity_supported(i) || gpu::is_vcn_busy_supported(i))
-            amd_smi_config_data::gpuID_vcn_support.insert(i);
+        if(gpu::is_jpeg_activity_supported(i))
+            amd_smi_config_data::gpuID_jpeg_activity_support.insert(i);
+        else if(gpu::is_jpeg_busy_supported(i))
+            amd_smi_config_data::gpuID_jpeg_busy_support.insert(i);
+
+        if(gpu::is_vcn_activity_supported(i))
+            amd_smi_config_data::gpuID_vcn_activity_support.insert(i);
+        else if(gpu::is_vcn_busy_supported(i))
+            amd_smi_config_data::gpuID_vcn_busy_support.insert(i);
     }
     return true;
 }
@@ -92,23 +101,52 @@ config_settings(const std::shared_ptr<settings>& _config)
     std::string default_metrics = "busy, temp, power, mem_usage";
     // List of gpu's that support JPEG and VCN activity
     // As of now, no distinction between busy and activity shown in description
-    std::string jpeg_support = "";
-    std::string vcn_support  = "";
+    std::string jpeg_activity_support = "";
+    std::string jpeg_busy_support     = "";
+    std::string vcn_activity_support  = "";
+    std::string vcn_busy_support      = "";
 
-    if(!amd_smi_config_data::gpuID_jpeg_support.empty())
+    if(!amd_smi_config_data::gpuID_jpeg_activity_support.empty())
     {
-        jpeg_support += ", jpeg_activity";
+        jpeg_activity_support += ", jpeg_activity (GPUs:";
+        for(const auto& id : amd_smi_config_data::gpuID_jpeg_activity_support)
+            jpeg_activity_support += " " + std::to_string(id) + ",";
+        jpeg_activity_support.pop_back();
+        jpeg_activity_support += ")";
     }
 
-    if(!amd_smi_config_data::gpuID_vcn_support.empty())
+    if(!amd_smi_config_data::gpuID_jpeg_busy_support.empty())
     {
-        vcn_support += ", vcn_activity";
+        jpeg_busy_support += ", jpeg_busy (GPUs:";
+        for(const auto& id : amd_smi_config_data::gpuID_jpeg_busy_support)
+            jpeg_busy_support += " " + std::to_string(id) + ",";
+        jpeg_busy_support.pop_back();
+        jpeg_busy_support += ")";
+    }
+
+    if(!amd_smi_config_data::gpuID_vcn_activity_support.empty())
+    {
+        vcn_activity_support += ", vcn_activity (GPUs:";
+        for(const auto& id : amd_smi_config_data::gpuID_vcn_activity_support)
+            vcn_activity_support += " " + std::to_string(id) + ",";
+        vcn_activity_support.pop_back();
+        vcn_activity_support += ")";
+    }
+
+    if(!amd_smi_config_data::gpuID_vcn_busy_support.empty())
+    {
+        vcn_busy_support += ", vcn_busy (GPUs:";
+        for(const auto& id : amd_smi_config_data::gpuID_vcn_busy_support)
+            vcn_busy_support += " " + std::to_string(id) + ",";
+        vcn_busy_support.pop_back();
+        vcn_busy_support += ")";
     }
 
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_AMD_SMI_METRICS",
-        "amd-smi metrics to collect: " + default_metrics + jpeg_support + vcn_support +
-            ". " + "An empty value implies 'all' and 'none' suppresses all.",
+        "amd-smi metrics to collect: " + default_metrics + jpeg_activity_support +
+            vcn_activity_support + jpeg_busy_support + vcn_busy_support + ". " +
+            "An empty value implies 'all' and 'none' suppresses all.",
         "busy, temp, power, mem_usage", "backend", "amd_smi", "rocm", "process_sampling");
 }
 }  // namespace amd_smi

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -71,8 +71,8 @@ get_setting_name(std::string _v)
 }  // namespace
 
 // See hpp for more information
-std::unordered_map<uint32_t> amd_smi_config_data::gpuID_vcn_support  = {};
-std::unordered_map<uint32_t> amd_smi_config_data::gpuID_jpeg_support = {};
+std::unordered_set<uint32_t> amd_smi_config_data::gpuID_vcn_support  = {};
+std::unordered_set<uint32_t> amd_smi_config_data::gpuID_jpeg_support = {};
 
 bool
 setup_config_check()
@@ -81,7 +81,7 @@ setup_config_check()
 
     // Get processors and activity support
     size_t device_count = gpu::get_processor_count();
-    for(size_t i = 0; i < amd_smi_config_data::device_count; i++)
+    for(size_t i = 0; i < device_count; i++)
     {
         if(gpu::is_jpeg_activity_supported(i) || gpu::is_jpeg_busy_supported(i))
             amd_smi_config_data::gpuID_jpeg_support.insert(i);
@@ -102,7 +102,7 @@ config_settings(const std::shared_ptr<settings>& _config)
     std::string jpeg_support = "";
     std::string vcn_support  = "";
 
-    if(!gpuID_jpeg_support.empty())
+    if(!amd_smi_config_data::gpuID_jpeg_support.empty())
     {
         jpeg_support += ", jpeg_activity (GPUs:";
         for(const auto& id : amd_smi_config_data::gpuID_jpeg_support)
@@ -111,7 +111,7 @@ config_settings(const std::shared_ptr<settings>& _config)
         jpeg_support += ")";
     }
 
-    if(!gpuID_vcn_support.empty())
+    if(!amd_smi_config_data::gpuID_vcn_support.empty())
     {
         vcn_support += ", vcn_activity (GPUs:";
         for(const auto& id : amd_smi_config_data::gpuID_vcn_support)
@@ -122,7 +122,7 @@ config_settings(const std::shared_ptr<settings>& _config)
 
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_AMD_SMI_METRICS",
-        "amd-smi metrics to collect: " + desc_metrics + jpeg_support + vcn_support +
+        "amd-smi metrics to collect: " + default_metrics + jpeg_support + vcn_support +
             ". " + "An empty value implies 'all' and 'none' suppresses all.",
         "busy, temp, power, mem_usage", "backend", "amd_smi", "rocm", "process_sampling");
 }

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -97,20 +97,12 @@ config_settings(const std::shared_ptr<settings>& _config)
 
     if(!amd_smi_config_data::gpuID_jpeg_support.empty())
     {
-        jpeg_support += ", jpeg_activity (GPUs:";
-        for(const auto& id : amd_smi_config_data::gpuID_jpeg_support)
-            jpeg_support += " " + std::to_string(id) + ",";
-        jpeg_support.pop_back();
-        jpeg_support += ")";
+        jpeg_support += ", jpeg_activity";
     }
 
     if(!amd_smi_config_data::gpuID_vcn_support.empty())
     {
-        vcn_support += ", vcn_activity (GPUs:";
-        for(const auto& id : amd_smi_config_data::gpuID_vcn_support)
-            vcn_support += " " + std::to_string(id) + ",";
-        vcn_support.pop_back();
-        vcn_support += ")";
+        vcn_support += ", vcn_activity";
     }
 
     ROCPROFSYS_CONFIG_SETTING(

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -65,47 +65,29 @@ get_setting_name(std::string _v)
         }()
 }  // namespace
 
-std::set<uint32_t> amd_smi_config_data::gpuID_vcn_activity_support  = {};
-std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_activity_support = {};
-// std::set<uint32_t> amd_smi_config_data::gpuID_vcn_busy_support      = {};
-// std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_busy_support     = {};
-
-bool
-setup_config_check()
+void
+config_settings(const std::shared_ptr<settings>& _config)
 {
-    if(!get_use_amd_smi() || !gpu::initialize_amdsmi()) return false;
+    if(!get_use_amd_smi() || !gpu::initialize_amdsmi()) return;
+
+    std::string default_metrics = "busy, temp, power, mem_usage";
+    // No distinction between busy and activity shown in description
+    std::string jpeg_activity_support = "";
+    std::string vcn_activity_support  = "";
+    bool        jpeg_added            = false;
+    bool        vcn_added             = false;
 
     size_t device_count = gpu::get_processor_count();
     for(size_t i = 0; i < device_count; i++)
     {
         if(gpu::is_vcn_activity_supported(i) || gpu::is_vcn_busy_supported(i))
-            amd_smi_config_data::gpuID_vcn_activity_support.insert(i);
+            vcn_added = true;
         if(gpu::is_jpeg_activity_supported(i) || gpu::is_jpeg_busy_supported(i))
-            amd_smi_config_data::gpuID_jpeg_activity_support.insert(i);
-    }
-    return true;
-}
-
-void
-config_settings(const std::shared_ptr<settings>& _config)
-{
-    if(!setup_config_check()) return;
-
-    std::string default_metrics = "busy, temp, power, mem_usage";
-    // List of gpu's that support JPEG and VCN activity
-    // No distinction between busy and activity shown in description
-    std::string jpeg_activity_support = "";
-    std::string vcn_activity_support  = "";
-
-    if(!amd_smi_config_data::gpuID_jpeg_activity_support.empty())
-    {
-        jpeg_activity_support += ", jpeg_activity";
+            jpeg_added = true;
     }
 
-    if(!amd_smi_config_data::gpuID_vcn_activity_support.empty())
-    {
-        vcn_activity_support += ", vcn_activity";
-    }
+    if(jpeg_added) jpeg_activity_support += ", jpeg_activity";
+    if(vcn_added) vcn_activity_support += ", vcn_activity";
 
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_AMD_SMI_METRICS",

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -31,6 +31,8 @@
 #include <string>
 #include <sys/resource.h>
 
+#define ROCPROFSYS_USE_ROCM 1
+
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 namespace rocprofsys
 {
@@ -74,20 +76,24 @@ config_settings(const std::shared_ptr<settings>& _config)
     // No distinction between busy and activity shown in description
     std::string jpeg_activity_support = "";
     std::string vcn_activity_support  = "";
-    bool        jpeg_added            = false;
-    bool        vcn_added             = false;
 
     size_t device_count = gpu::get_processor_count();
     for(size_t i = 0; i < device_count; i++)
     {
         if(gpu::is_vcn_activity_supported(i) || gpu::is_vcn_busy_supported(i))
-            vcn_added = true;
-        if(gpu::is_jpeg_activity_supported(i) || gpu::is_jpeg_busy_supported(i))
-            jpeg_added = true;
+        {
+            vcn_activity_support += ", vcn_activity";
+            break;
+        }
     }
-
-    if(jpeg_added) jpeg_activity_support += ", jpeg_activity";
-    if(vcn_added) vcn_activity_support += ", vcn_activity";
+    for(size_t i = 0; i < device_count; i++)
+    {
+        if(gpu::is_jpeg_activity_supported(i) || gpu::is_jpeg_busy_supported(i))
+        {
+            jpeg_activity_support += ", jpeg_activity";
+            break;
+        }
+    }
 
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_AMD_SMI_METRICS",

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -31,7 +31,6 @@
 #include <string>
 #include <sys/resource.h>
 
-#define ROCPROFSYS_USE_ROCM 1
 
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 namespace rocprofsys
@@ -69,8 +68,8 @@ get_setting_name(std::string _v)
 
 std::set<uint32_t> amd_smi_config_data::gpuID_vcn_activity_support  = {};
 std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_activity_support = {};
-std::set<uint32_t> amd_smi_config_data::gpuID_vcn_busy_support      = {};
-std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_busy_support     = {};
+// std::set<uint32_t> amd_smi_config_data::gpuID_vcn_busy_support      = {};
+// std::set<uint32_t> amd_smi_config_data::gpuID_jpeg_busy_support     = {};
 
 bool
 setup_config_check()
@@ -80,15 +79,20 @@ setup_config_check()
     size_t device_count = gpu::get_processor_count();
     for(size_t i = 0; i < device_count; i++)
     {
-        if(gpu::is_jpeg_activity_supported(i))
-            amd_smi_config_data::gpuID_jpeg_activity_support.insert(i);
-        else if(gpu::is_jpeg_busy_supported(i))
-            amd_smi_config_data::gpuID_jpeg_busy_support.insert(i);
+        // if(gpu::is_jpeg_activity_supported(i))
+        //     amd_smi_config_data::gpuID_jpeg_activity_support.insert(i);
+        // else if(gpu::is_jpeg_busy_supported(i))
+        //     amd_smi_config_data::gpuID_jpeg_busy_support.insert(i);
 
-        if(gpu::is_vcn_activity_supported(i))
+        // if(gpu::is_vcn_activity_supported(i))
+        //     amd_smi_config_data::gpuID_vcn_activity_support.insert(i);
+        // else if(gpu::is_vcn_busy_supported(i))
+        //     amd_smi_config_data::gpuID_vcn_busy_support.insert(i);
+
+        if(gpu::is_vcn_activity_supported(i) || gpu::is_vcn_busy_supported(i))
             amd_smi_config_data::gpuID_vcn_activity_support.insert(i);
-        else if(gpu::is_vcn_busy_supported(i))
-            amd_smi_config_data::gpuID_vcn_busy_support.insert(i);
+        if(gpu::is_jpeg_activity_supported(i) || gpu::is_jpeg_busy_supported(i))
+            amd_smi_config_data::gpuID_jpeg_activity_support.insert(i);
     }
     return true;
 }
@@ -102,51 +106,54 @@ config_settings(const std::shared_ptr<settings>& _config)
     // List of gpu's that support JPEG and VCN activity
     // As of now, no distinction between busy and activity shown in description
     std::string jpeg_activity_support = "";
-    std::string jpeg_busy_support     = "";
+    // std::string jpeg_busy_support     = "";
     std::string vcn_activity_support  = "";
-    std::string vcn_busy_support      = "";
+    // std::string vcn_busy_support      = "";
 
     if(!amd_smi_config_data::gpuID_jpeg_activity_support.empty())
     {
-        jpeg_activity_support += ", jpeg_activity (GPUs:";
-        for(const auto& id : amd_smi_config_data::gpuID_jpeg_activity_support)
-            jpeg_activity_support += " " + std::to_string(id) + ",";
-        jpeg_activity_support.pop_back();
-        jpeg_activity_support += ")";
+        // jpeg_activity_support += ", jpeg_activity (GPUs:";
+        // for(const auto& id : amd_smi_config_data::gpuID_jpeg_activity_support)
+        //     jpeg_activity_support += " " + std::to_string(id) + ",";
+        // jpeg_activity_support.pop_back();
+        // jpeg_activity_support += ")";
+        jpeg_activity_support += ", jpeg_activity";
     }
 
-    if(!amd_smi_config_data::gpuID_jpeg_busy_support.empty())
-    {
-        jpeg_busy_support += ", jpeg_busy (GPUs:";
-        for(const auto& id : amd_smi_config_data::gpuID_jpeg_busy_support)
-            jpeg_busy_support += " " + std::to_string(id) + ",";
-        jpeg_busy_support.pop_back();
-        jpeg_busy_support += ")";
-    }
+    // if(!amd_smi_config_data::gpuID_jpeg_busy_support.empty())
+    // {
+    //     jpeg_busy_support += ", jpeg_busy (GPUs:";
+    //     for(const auto& id : amd_smi_config_data::gpuID_jpeg_busy_support)
+    //         jpeg_busy_support += " " + std::to_string(id) + ",";
+    //     jpeg_busy_support.pop_back();
+    //     jpeg_busy_support += ")";
+    // }
 
     if(!amd_smi_config_data::gpuID_vcn_activity_support.empty())
     {
-        vcn_activity_support += ", vcn_activity (GPUs:";
-        for(const auto& id : amd_smi_config_data::gpuID_vcn_activity_support)
-            vcn_activity_support += " " + std::to_string(id) + ",";
-        vcn_activity_support.pop_back();
-        vcn_activity_support += ")";
+        // vcn_activity_support += ", vcn_activity (GPUs:";
+        // for(const auto& id : amd_smi_config_data::gpuID_vcn_activity_support)
+        //     vcn_activity_support += " " + std::to_string(id) + ",";
+        // vcn_activity_support.pop_back();
+        // vcn_activity_support += ")";
+        vcn_activity_support += ", vcn_activity";
     }
 
-    if(!amd_smi_config_data::gpuID_vcn_busy_support.empty())
-    {
-        vcn_busy_support += ", vcn_busy (GPUs:";
-        for(const auto& id : amd_smi_config_data::gpuID_vcn_busy_support)
-            vcn_busy_support += " " + std::to_string(id) + ",";
-        vcn_busy_support.pop_back();
-        vcn_busy_support += ")";
-    }
+    // if(!amd_smi_config_data::gpuID_vcn_busy_support.empty())
+    // {
+    //     vcn_busy_support += ", vcn_busy (GPUs:";
+    //     for(const auto& id : amd_smi_config_data::gpuID_vcn_busy_support)
+    //         vcn_busy_support += " " + std::to_string(id) + ",";
+    //     vcn_busy_support.pop_back();
+    //     vcn_busy_support += ")";
+    // }
 
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_AMD_SMI_METRICS",
-        "amd-smi metrics to collect: " + default_metrics + jpeg_activity_support +
-            vcn_activity_support + jpeg_busy_support + vcn_busy_support + ". " +
-            "An empty value implies 'all' and 'none' suppresses all.",
+        "amd-smi metrics to collect: " + default_metrics + 
+         jpeg_activity_support + vcn_activity_support + 
+    //     jpeg_busy_support + vcn_busy_support + 
+         ". " + "An empty value implies 'all' and 'none' suppresses all.",
         "busy, temp, power, mem_usage", "backend", "amd_smi", "rocm", "process_sampling");
 }
 }  // namespace amd_smi

--- a/source/lib/core/amd_smi.cpp
+++ b/source/lib/core/amd_smi.cpp
@@ -31,8 +31,6 @@
 #include <string>
 #include <sys/resource.h>
 
-#define ROCPROFSYS_USE_ROCM 1
-
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 namespace rocprofsys
 {

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -55,8 +55,8 @@ setup_config_check();
 
 struct amd_smi_config_data
 {
-    static unordered_map<uint32_t> gpuID_vcn_support;
-    static unordered_map<uint32_t> gpuID_jpeg_support;
+    static std::unordered_set<uint32_t> gpuID_vcn_support;
+    static std::unordered_set<uint32_t> gpuID_jpeg_support;
 
 private:
     friend bool rocprofsys::amd_smi::setup_config_check();

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -33,7 +33,6 @@
 #include <tuple>
 #include <type_traits>
 
-
 #if ROCPROFSYS_USE_ROCM > 0
 #    include <amd_smi/amdsmi.h>
 #endif

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -26,12 +26,12 @@
 #include <chrono>
 #include <future>
 #include <limits>
+#include <map>
 #include <memory>
 #include <ratio>
 #include <thread>
 #include <tuple>
 #include <type_traits>
-#include <map>
 
 #if ROCPROFSYS_USE_ROCM > 0
 #    include <amd_smi/amdsmi.h>

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -1,0 +1,77 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "core/timemory.hpp"
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <future>
+#include <limits>
+#include <memory>
+#include <ratio>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#if ROCPROFSYS_USE_ROCM > 0
+#    include <amd_smi/amdsmi.h>
+#endif
+
+namespace rocprofsys
+{
+namespace amd_smi
+{
+void
+config_settings(const std::shared_ptr<settings>&);
+
+#if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
+
+void
+setup_config_check();
+
+// Needed for get_settings()
+struct amd_smi_settings
+{
+    bool jpeg_activity = true;
+    bool vcn_activity  = true;
+};
+
+struct amd_smi_config_data
+{
+    static bool track_jpeg_activity;
+
+private:
+    friend void rocprofsys::amd_smi::setup_config_check();
+    friend void rocprofsys::amd_smi::config_settings(const std::shared_ptr<settings>&);
+
+    static std::set<uint32_t> device_list;
+    static size_t             device_count;
+};
+
+#endif
+}  // namespace amd_smi
+}  // namespace rocprofsys

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -50,27 +50,17 @@ config_settings(const std::shared_ptr<settings>&);
 
 #if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
 
-void
+bool
 setup_config_check();
-
-// Needed for get_settings()
-struct amd_smi_settings
-{
-    bool jpeg_activity = true;
-    bool vcn_activity  = true;
-};
 
 struct amd_smi_config_data
 {
-    static bool track_jpeg_activity;
-    static bool track_vcn_activity;
+    static unordered_map<uint32_t> gpuID_vcn_support;
+    static unordered_map<uint32_t> gpuID_jpeg_support;
 
 private:
-    friend void rocprofsys::amd_smi::setup_config_check();
+    friend bool rocprofsys::amd_smi::setup_config_check();
     friend void rocprofsys::amd_smi::config_settings(const std::shared_ptr<settings>&);
-
-    static std::set<uint32_t> device_list;
-    static size_t             device_count;
 };
 
 #endif

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -20,18 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#pragma once
-
 #include "core/timemory.hpp"
-#include <chrono>
-#include <future>
-#include <limits>
-#include <map>
-#include <memory>
-#include <ratio>
-#include <thread>
-#include <tuple>
-#include <type_traits>
 
 #if ROCPROFSYS_USE_ROCM > 0
 #    include <amd_smi/amdsmi.h>
@@ -43,24 +32,5 @@ namespace amd_smi
 {
 void
 config_settings(const std::shared_ptr<settings>&);
-
-#if defined(ROCPROFSYS_USE_ROCM) && ROCPROFSYS_USE_ROCM > 0
-
-bool
-setup_config_check();
-
-struct amd_smi_config_data
-{
-    static std::set<uint32_t> gpuID_vcn_activity_support;
-    // static std::set<uint32_t> gpuID_vcn_busy_support;
-    static std::set<uint32_t> gpuID_jpeg_activity_support;
-    // static std::set<uint32_t> gpuID_jpeg_busy_support;
-
-private:
-    friend bool rocprofsys::amd_smi::setup_config_check();
-    friend void rocprofsys::amd_smi::config_settings(const std::shared_ptr<settings>&);
-};
-
-#endif
 }  // namespace amd_smi
 }  // namespace rocprofsys

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -33,7 +33,6 @@
 #include <tuple>
 #include <type_traits>
 
-#define ROCPROFSYS_USE_ROCM 1
 
 #if ROCPROFSYS_USE_ROCM > 0
 #    include <amd_smi/amdsmi.h>
@@ -54,9 +53,9 @@ setup_config_check();
 struct amd_smi_config_data
 {
     static std::set<uint32_t> gpuID_vcn_activity_support;
-    static std::set<uint32_t> gpuID_vcn_busy_support;
+    // static std::set<uint32_t> gpuID_vcn_busy_support;
     static std::set<uint32_t> gpuID_jpeg_activity_support;
-    static std::set<uint32_t> gpuID_jpeg_busy_support;
+    // static std::set<uint32_t> gpuID_jpeg_busy_support;
 
 private:
     friend bool rocprofsys::amd_smi::setup_config_check();

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -24,8 +24,6 @@
 
 #include "core/timemory.hpp"
 #include <chrono>
-#include <cstdint>
-#include <deque>
 #include <future>
 #include <limits>
 #include <memory>
@@ -33,9 +31,7 @@
 #include <thread>
 #include <tuple>
 #include <type_traits>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
+#include <map>
 
 #if ROCPROFSYS_USE_ROCM > 0
 #    include <amd_smi/amdsmi.h>
@@ -55,8 +51,8 @@ setup_config_check();
 
 struct amd_smi_config_data
 {
-    static std::unordered_set<uint32_t> gpuID_vcn_support;
-    static std::unordered_set<uint32_t> gpuID_jpeg_support;
+    static std::set<uint32_t> gpuID_vcn_support;
+    static std::set<uint32_t> gpuID_jpeg_support;
 
 private:
     friend bool rocprofsys::amd_smi::setup_config_check();

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -63,6 +63,7 @@ struct amd_smi_settings
 struct amd_smi_config_data
 {
     static bool track_jpeg_activity;
+    static bool track_vcn_activity;
 
 private:
     friend void rocprofsys::amd_smi::setup_config_check();

--- a/source/lib/core/amd_smi.hpp
+++ b/source/lib/core/amd_smi.hpp
@@ -33,6 +33,8 @@
 #include <tuple>
 #include <type_traits>
 
+#define ROCPROFSYS_USE_ROCM 1
+
 #if ROCPROFSYS_USE_ROCM > 0
 #    include <amd_smi/amdsmi.h>
 #endif
@@ -51,8 +53,10 @@ setup_config_check();
 
 struct amd_smi_config_data
 {
-    static std::set<uint32_t> gpuID_vcn_support;
-    static std::set<uint32_t> gpuID_jpeg_support;
+    static std::set<uint32_t> gpuID_vcn_activity_support;
+    static std::set<uint32_t> gpuID_vcn_busy_support;
+    static std::set<uint32_t> gpuID_jpeg_activity_support;
+    static std::set<uint32_t> gpuID_jpeg_busy_support;
 
 private:
     friend bool rocprofsys::amd_smi::setup_config_check();

--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "config.hpp"
+#include "amd_smi.hpp"
 #include "common/defines.h"
 #include "common/static_object.hpp"
 #include "constraint.hpp"
@@ -626,13 +627,7 @@ configure_settings(bool _init)
         ->set_choices(perf::get_config_choices());
 
     rocprofiler_sdk::config_settings(_config);
-
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_AMD_SMI_METRICS",
-                              "amd-smi metrics to collect: busy, temp, power, "
-                              "vcn_activity, jpeg_activity, mem_usage. "
-                              "An empty value implies 'all' and 'none' suppresses all.",
-                              "busy, temp, power, mem_usage", "backend", "amd_smi",
-                              "rocm", "process_sampling");
+    amd_smi::config_settings(_config);
 
     ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB",
                               "Hint for shared-memory buffer size in perfetto (in KB)",

--- a/source/lib/core/gpu.cpp
+++ b/source/lib/core/gpu.cpp
@@ -293,6 +293,7 @@ get_processor_handles()
                             break;
                         }
                     }
+                    if(v_busy_supported && j_busy_supported) break;
                 }
             }
             processors::vcn_activity_supported.push_back(vcn_supported);

--- a/source/lib/core/gpu.cpp
+++ b/source/lib/core/gpu.cpp
@@ -203,6 +203,10 @@ add_device_metadata()
 
 uint32_t                             processors::total_processor_count = 0;
 std::vector<amdsmi_processor_handle> processors::processors_list       = {};
+std::vector<bool>                    processors::vcn_activity_supported = {};
+std::vector<bool>                    processors::jpeg_activity_supported = {};
+std::vector<bool>                    processors::vcn_busy_supported = {};
+std::vector<bool>                    processors::jpeg_busy_supported = {};
 
 void
 get_processor_handles()
@@ -246,10 +250,92 @@ get_processor_handles()
                 return;
             }
             processors::processors_list.push_back(processor);
+
+            amdsmi_gpu_metrics_t gpu_metrics;
+            bool vcn_supported = false;
+            bool jpeg_supported = false;
+            bool v_busy_supported = false;
+            bool j_busy_supported = false;
+            ret = amdsmi_get_gpu_metrics_info(processor, &gpu_metrics);
+            if(ret == AMDSMI_STATUS_SUCCESS)
+            {
+                for(const auto& vcn_activity : gpu_metrics.vcn_activity)
+                {
+                    if(vcn_activity != UINT16_MAX)
+                    {
+                        vcn_supported = true;
+                        break;
+                    }
+                }
+                for(const auto& jpeg_activity : gpu_metrics.jpeg_activity)
+                {
+                    if(jpeg_activity != UINT16_MAX)
+                    {
+                        jpeg_supported = true;
+                        break;
+                    }
+                }
+                for(const auto& xcp : gpu_metrics.xcp_stats)
+                {
+                    for(const auto& vcn_busy : xcp.vcn_busy)
+                    {
+                        if(vcn_busy != UINT16_MAX)
+                        {
+                            v_busy_supported = true;
+                            break;
+                        }
+                    }
+                    for(const auto& jpeg_busy : xcp.jpeg_busy)
+                    {
+                        if(jpeg_busy != UINT16_MAX)
+                        {
+                            j_busy_supported = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            processors::vcn_activity_supported.push_back(vcn_supported);
+            processors::jpeg_activity_supported.push_back(jpeg_supported);
+            processors::vcn_busy_supported.push_back(v_busy_supported);
+            processors::jpeg_busy_supported.push_back(j_busy_supported);
         }
     }
     processors::total_processor_count = processors::processors_list.size();
 }
+
+bool
+is_vcn_activity_supported(uint32_t dev_id)
+{
+    if(dev_id >= processors::vcn_activity_supported.size())
+        return false;
+    return processors::vcn_activity_supported[dev_id];
+}
+
+bool
+is_jpeg_activity_supported(uint32_t dev_id)
+{
+    if(dev_id >= processors::jpeg_activity_supported.size())
+        return false;
+    return processors::jpeg_activity_supported[dev_id];
+}
+
+bool
+is_vcn_busy_supported(uint32_t dev_id)
+{
+    if(dev_id >= processors::vcn_busy_supported.size())
+        return false;
+    return processors::vcn_busy_supported[dev_id];
+}
+
+bool
+is_jpeg_busy_supported(uint32_t dev_id)
+{
+    if(dev_id >= processors::jpeg_busy_supported.size())
+        return false;
+    return processors::jpeg_busy_supported[dev_id];
+}
+
 uint32_t
 get_processor_count()
 {

--- a/source/lib/core/gpu.cpp
+++ b/source/lib/core/gpu.cpp
@@ -277,22 +277,20 @@ get_processor_handles()
                 }
                 for(const auto& xcp : gpu_metrics.xcp_stats)
                 {
-                    for(const auto& vcn_busy : xcp.vcn_busy)
+                    if(!v_busy_supported)
                     {
-                        if(vcn_busy != UINT16_MAX)
-                        {
-                            v_busy_supported = true;
-                            break;
-                        }
+                        v_busy_supported =
+                            std::any_of(std::begin(xcp.vcn_busy), std::end(xcp.vcn_busy),
+                                        [](uint16_t val) { return val != UINT16_MAX; });
                     }
-                    for(const auto& jpeg_busy : xcp.jpeg_busy)
+
+                    if(!j_busy_supported)
                     {
-                        if(jpeg_busy != UINT16_MAX)
-                        {
-                            j_busy_supported = true;
-                            break;
-                        }
+                        j_busy_supported = std::any_of(
+                            std::begin(xcp.jpeg_busy), std::end(xcp.jpeg_busy),
+                            [](uint16_t val) { return val != UINT16_MAX; });
                     }
+
                     if(v_busy_supported && j_busy_supported) break;
                 }
             }

--- a/source/lib/core/gpu.cpp
+++ b/source/lib/core/gpu.cpp
@@ -201,12 +201,12 @@ add_device_metadata()
  * Required amdsmi methods to get processors and handles
  */
 
-uint32_t                             processors::total_processor_count = 0;
-std::vector<amdsmi_processor_handle> processors::processors_list       = {};
-std::vector<bool>                    processors::vcn_activity_supported = {};
+uint32_t                             processors::total_processor_count   = 0;
+std::vector<amdsmi_processor_handle> processors::processors_list         = {};
+std::vector<bool>                    processors::vcn_activity_supported  = {};
 std::vector<bool>                    processors::jpeg_activity_supported = {};
-std::vector<bool>                    processors::vcn_busy_supported = {};
-std::vector<bool>                    processors::jpeg_busy_supported = {};
+std::vector<bool>                    processors::vcn_busy_supported      = {};
+std::vector<bool>                    processors::jpeg_busy_supported     = {};
 
 void
 get_processor_handles()
@@ -252,10 +252,10 @@ get_processor_handles()
             processors::processors_list.push_back(processor);
 
             amdsmi_gpu_metrics_t gpu_metrics;
-            bool vcn_supported = false;
-            bool jpeg_supported = false;
-            bool v_busy_supported = false;
-            bool j_busy_supported = false;
+            bool                 vcn_supported    = false;
+            bool                 jpeg_supported   = false;
+            bool                 v_busy_supported = false;
+            bool                 j_busy_supported = false;
             ret = amdsmi_get_gpu_metrics_info(processor, &gpu_metrics);
             if(ret == AMDSMI_STATUS_SUCCESS)
             {
@@ -307,32 +307,28 @@ get_processor_handles()
 bool
 is_vcn_activity_supported(uint32_t dev_id)
 {
-    if(dev_id >= processors::vcn_activity_supported.size())
-        return false;
+    if(dev_id >= processors::vcn_activity_supported.size()) return false;
     return processors::vcn_activity_supported[dev_id];
 }
 
 bool
 is_jpeg_activity_supported(uint32_t dev_id)
 {
-    if(dev_id >= processors::jpeg_activity_supported.size())
-        return false;
+    if(dev_id >= processors::jpeg_activity_supported.size()) return false;
     return processors::jpeg_activity_supported[dev_id];
 }
 
 bool
 is_vcn_busy_supported(uint32_t dev_id)
 {
-    if(dev_id >= processors::vcn_busy_supported.size())
-        return false;
+    if(dev_id >= processors::vcn_busy_supported.size()) return false;
     return processors::vcn_busy_supported[dev_id];
 }
 
 bool
 is_jpeg_busy_supported(uint32_t dev_id)
 {
-    if(dev_id >= processors::jpeg_busy_supported.size())
-        return false;
+    if(dev_id >= processors::jpeg_busy_supported.size()) return false;
     return processors::jpeg_busy_supported[dev_id];
 }
 

--- a/source/lib/core/gpu.hpp
+++ b/source/lib/core/gpu.hpp
@@ -40,15 +40,35 @@ get_processor_count();
 amdsmi_processor_handle
 get_handle_from_id(uint32_t dev_id);
 
+bool
+is_vcn_activity_supported(uint32_t dev_id);
+
+bool
+is_jpeg_activity_supported(uint32_t dev_id);
+
+bool
+is_vcn_busy_supported(uint32_t dev_id);
+
+bool
+is_jpeg_busy_supported(uint32_t dev_id);
+
 struct processors
 {
     static uint32_t                             total_processor_count;
     static std::vector<amdsmi_processor_handle> processors_list;
+    static std::vector<bool>                    vcn_activity_supported;
+    static std::vector<bool>                    jpeg_activity_supported;
+    static std::vector<bool>                    vcn_busy_supported;
+    static std::vector<bool>                    jpeg_busy_supported;
 
 private:
     friend void                    rocprofsys::gpu::get_processor_handles();
     friend uint32_t                rocprofsys::gpu::get_processor_count();
     friend amdsmi_processor_handle rocprofsys::gpu::get_handle_from_id(uint32_t dev_id);
+    friend bool                    rocprofsys::gpu::is_vcn_activity_supported(uint32_t dev_id);
+    friend bool                    rocprofsys::gpu::is_jpeg_activity_supported(uint32_t dev_id);
+    friend bool                    rocprofsys::gpu::is_vcn_busy_supported(uint32_t dev_id);
+    friend bool                    rocprofsys::gpu::is_jpeg_busy_supported(uint32_t dev_id);
 };
 #endif
 

--- a/source/lib/core/gpu.hpp
+++ b/source/lib/core/gpu.hpp
@@ -65,10 +65,10 @@ private:
     friend void                    rocprofsys::gpu::get_processor_handles();
     friend uint32_t                rocprofsys::gpu::get_processor_count();
     friend amdsmi_processor_handle rocprofsys::gpu::get_handle_from_id(uint32_t dev_id);
-    friend bool                    rocprofsys::gpu::is_vcn_activity_supported(uint32_t dev_id);
-    friend bool                    rocprofsys::gpu::is_jpeg_activity_supported(uint32_t dev_id);
-    friend bool                    rocprofsys::gpu::is_vcn_busy_supported(uint32_t dev_id);
-    friend bool                    rocprofsys::gpu::is_jpeg_busy_supported(uint32_t dev_id);
+    friend bool rocprofsys::gpu::is_vcn_activity_supported(uint32_t dev_id);
+    friend bool rocprofsys::gpu::is_jpeg_activity_supported(uint32_t dev_id);
+    friend bool rocprofsys::gpu::is_vcn_busy_supported(uint32_t dev_id);
+    friend bool rocprofsys::gpu::is_jpeg_busy_supported(uint32_t dev_id);
 };
 #endif
 


### PR DESCRIPTION
Samples GPU's to verify if jpeg and vcn (activity/busy) are supported. No distinction is given between activity and busy. For example, if there is no "jpeg_activity" but there is "jepg_busy", then the config will list it under "jpeg_activity".

Improved rocprof-sys-avail to report VCN and JPEG activity as supported values for ROCPROFSYS_AMD_SMI_METRICS after querying using amd-smi.