### PR TITLE
Update from version 1.0.0 to 1.0.1 in environment configurations docs

### DIFF
--- a/docs/how-to/configuring-validating-environment.rst
+++ b/docs/how-to/configuring-validating-environment.rst
@@ -40,8 +40,8 @@ using ``module load rocprofiler-systems/<VERSION>`` and unloaded using ``module 
 
 .. code-block:: shell
 
-   module load rocprofiler-systems/1.0.0
-   module unload rocprofiler-systems/1.0.0
+   module load rocprofiler-systems/1.0.1
+   module unload rocprofiler-systems/1.0.1
 
 .. note::
 

--- a/docs/how-to/configuring-validating-environment.rst
+++ b/docs/how-to/configuring-validating-environment.rst
@@ -40,8 +40,8 @@ using ``module load rocprofiler-systems/<VERSION>`` and unloaded using ``module 
 
 .. code-block:: shell
 
-   module load rocprofiler-systems/1.0.1
-   module unload rocprofiler-systems/1.0.1
+   module use /opt/rocprofiler-systems/share/modulefiles
+   module load rocprofiler-systems
 
 .. note::
 


### PR DESCRIPTION
rocprofiler-systems version in the "Configuring the environment" section of docs ([here](https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/how-to/configuring-validating-environment.html)) should be 1.0.1 now instead of 1.0.0