### PR TITLE
[SWDEV-535603]Fix: Add rocjpeg_api to supported ROCPROFSYS_ROCM_DOMAINS list

### DIFF
--- a/source/lib/core/rocprofiler-sdk.cpp
+++ b/source/lib/core/rocprofiler-sdk.cpp
@@ -328,6 +328,7 @@ config_settings(const std::shared_ptr<settings>& _config)
     _add_domain("hip_api");
     _add_domain("hsa_api");
     _add_domain("marker_api");
+    _add_domain("rocjpeg_api");
 
     for(const auto& itr : buffered_tracing_info)
         _add_domain(itr.name);


### PR DESCRIPTION
This change prevents runtime errors caused by the environment variable 
ROCPROFSYS_ROCM_DOMAINS including 'rocjpeg_api' when the domain is not 
listed in the allowed choices.

- Explicitly adds 'rocjpeg_api' to valid domain choices
- Enables rocjpeg callback tracing for ROCProfiler SDK >= 7.0
- Fixes crash due to unsupported domain value during get_callback_domains()

Tested with local ROCJPEG samples and rocprof-sys-sample execution.