### PR TITLE
Add perfetto validation to rccl ctests

### DIFF
--- a/tests/rocprof-sys-rccl-tests.cmake
+++ b/tests/rocprof-sys-rccl-tests.cmake
@@ -82,4 +82,11 @@ foreach(_TARGET ${RCCL_TEST_TARGETS})
                  -s
                  1
         ENVIRONMENT "${_rccl_environment}")
+
+    rocprofiler_systems_add_validation_test(
+        NAME rccl-test-${_NAME}-sampling
+        PERFETTO_METRIC "rocm_rccl_api"
+        PERFETTO_FILE "perfetto-trace.proto"
+        LABELS "rccl-tests;rcclp"
+        ARGS --counter-names "RCCL Comm" -p)
 endforeach()


### PR DESCRIPTION
Check for the "RCCL Communication Send / Receive" data counters

# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes n/a

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [x] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
Add a CTest check the RCCL tests for Communication Send / Receive counters. Just the "sampling" tests, for now.

## Have you added or updated tests to validate functionality?

- [x] Yes
- [ ] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
