### PR TITLE
Unhandled enum in switch statement

### DIFF
--- a/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -556,6 +556,9 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
             case ROCPROFILER_CALLBACK_TRACING_MEMORY_ALLOCATION:
             case ROCPROFILER_CALLBACK_TRACING_RUNTIME_INITIALIZATION:
 #endif
+#if(ROCPROFILER_VERSION >= 700)
+            case ROCPROFILER_CALLBACK_TRACING_HIP_STREAM:
+#endif
             {
                 ROCPROFSYS_CI_ABORT(true, "unhandled callback record kind: %i\n",
                                     record.kind);
@@ -652,6 +655,9 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
             case ROCPROFILER_CALLBACK_TRACING_OMPT:
             case ROCPROFILER_CALLBACK_TRACING_MEMORY_ALLOCATION:
             case ROCPROFILER_CALLBACK_TRACING_RUNTIME_INITIALIZATION:
+#endif
+#if(ROCPROFILER_VERSION >= 700)
+            case ROCPROFILER_CALLBACK_TRACING_HIP_STREAM:
 #endif
             {
                 ROCPROFSYS_CI_ABORT(true, "unhandled callback record kind: %i\n",


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
Add `ROCPROFILER_CALLBACK_TRACING_HIP_STREAM` to the switch statement in callback handlers. For now, just output a warning for the unhandled callback.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
