### PR TITLE
Removing dyninst builds from CI dockers

### DIFF
--- a/docker/Dockerfile.opensuse.ci
+++ b/docker/Dockerfile.opensuse.ci
@@ -33,19 +33,6 @@ RUN zypper --non-interactive update -y && \
     zypper --non-interactive clean --all && \
     python3 -m pip install 'cmake==3.21' perfetto
 
-COPY ./dyninst-source /tmp/dyninst
-
-RUN cd /tmp/dyninst && \
-    cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_BOOST=ON -DBUILD_TBB=ON \
-        -DBUILD_ELFUTILS=ON -DBUILD_LIBIBERTY=ON \
-        -DElfUtils_DOWNLOAD_VERSION=${ELFUTILS_DOWNLOAD_VERSION} \
-        -DBOOST_DOWNLOAD_VERSION=${BOOST_DOWNLOAD_VERSION} && \
-    cmake --build build --target all --parallel ${NJOBS} && \
-    cmake --build build --target install --parallel ${NJOBS} && \
-    cd /tmp && \
-    shopt -s dotglob extglob && \
-    rm -rf *
-
 ARG PYTHON_VERSIONS="6 7 8 9 10 11 12 13"
 
 RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh && \

--- a/docker/Dockerfile.rhel.ci
+++ b/docker/Dockerfile.rhel.ci
@@ -24,19 +24,6 @@ RUN yum groupinstall -y "Development Tools" && \
     yum clean all && \
     python3 -m pip install 'cmake==3.21' perfetto
 
-COPY ./dyninst-source /tmp/dyninst
-
-RUN cd /tmp/dyninst && \
-    cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_BOOST=ON \
-        -DBUILD_TBB=ON -DBUILD_ELFUTILS=ON -DBUILD_LIBIBERTY=ON \
-        -DElfUtils_DOWNLOAD_VERSION=${ELFUTILS_DOWNLOAD_VERSION} \
-        -DBOOST_DOWNLOAD_VERSION=${BOOST_DOWNLOAD_VERSION} && \
-    cmake --build build --target all --parallel ${NJOBS} && \
-    cmake --build build --target install --parallel ${NJOBS} && \
-    cd /tmp && \
-    shopt -s dotglob extglob && \
-    rm -rf *
-
 ARG PYTHON_VERSIONS="6 7 8 9 10 11 12 13"
 
 RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh && \

--- a/docker/Dockerfile.ubuntu.ci
+++ b/docker/Dockerfile.ubuntu.ci
@@ -36,19 +36,6 @@ RUN apt-get update && \
         python3 -m pip install 'cmake==3.21' perfetto; \
     fi
 
-COPY ./dyninst-source /tmp/dyninst
-
-RUN cd /tmp/dyninst && \
-    cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_BOOST=ON \
-        -DBUILD_TBB=ON -DBUILD_ELFUTILS=ON -DBUILD_LIBIBERTY=ON \
-        -DElfUtils_DOWNLOAD_VERSION=${ELFUTILS_DOWNLOAD_VERSION} \
-        -DBOOST_DOWNLOAD_VERSION=${BOOST_DOWNLOAD_VERSION} && \
-    cmake --build build --target all --parallel ${NJOBS} && \
-    cmake --build build --target install --parallel ${NJOBS} && \
-    cd /tmp && \
-    shopt -s dotglob extglob && \
-    rm -rf *
-
 ARG PYTHON_VERSIONS="6 7 8 9 10 11 12 13"
 
 RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniforge.sh && \


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [x] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
Removing the pre-build Dyninst build from the CI docker files. After the update to v13, this build procedure is no longer supported, and the docker-update workflow will fail.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
