### PR TITLE
Add `thread` header to videodecode example

### DIFF
--- a/examples/videodecode/roc_video_dec.h
+++ b/examples/videodecode/roc_video_dec.h
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include <stdint.h>
 #include <string.h>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 extern "C"


### PR DESCRIPTION
# rocprofiler-systems Pull Request

Fixes build errors for videodecode example in Azure CI, following HIP 7 breaking changes. 
`examples/videodecode/roc_video_dec.h:468:41: error: ‘std::thread’ has not been declared`
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34750&view=logs&j=cc73ccad-02ee-575a-6bec-084315eea8f3&t=85193e83-4c92-58d3-0251-7d37056d14b9&l=603

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
