### PR TITLE
Modified nic-performance test to download a smaller file

### DIFF
--- a/tests/rocprof-sys-nic-perf.cmake
+++ b/tests/rocprof-sys-nic-perf.cmake
@@ -50,9 +50,7 @@ set(_nic_perf_environment
 
 # Set _download_url to a large file that will give rocprof-sys-sample time to collect NIC
 # performance data (but not too large, because each test will time out after 2 min).
-set(_download_url
-    "https://ftp.wayne.edu/gnu/gcc/gcc-15.1.0/gcc-14.2.0-15.1.0.diff.gz"
-    )
+set(_download_url "https://ftp.wayne.edu/gnu/gcc/gcc-15.1.0/gcc-14.2.0-15.1.0.diff.gz")
 
 # Run the NIC performance test
 add_test(

--- a/tests/rocprof-sys-nic-perf.cmake
+++ b/tests/rocprof-sys-nic-perf.cmake
@@ -49,9 +49,9 @@ set(_nic_perf_environment
     "ROCPROFSYS_SAMPLING_DELAY=0.05")
 
 # Set _download_url to a large file that will give rocprof-sys-sample time to collect NIC
-# performance data.
+# performance data (but not too large, because each test will time out after 2 min).
 set(_download_url
-    "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.0/clang+llvm-20.1.0-armv7a-linux-gnueabihf.tar.gz"
+    "https://ftp.wayne.edu/gnu/gcc/gcc-15.1.0/gcc-14.2.0-15.1.0.diff.gz"
     )
 
 # Run the NIC performance test

--- a/tests/rocprof-sys-nic-perf.cmake
+++ b/tests/rocprof-sys-nic-perf.cmake
@@ -50,7 +50,9 @@ set(_nic_perf_environment
 
 # Set _download_url to a large file that will give rocprof-sys-sample time to collect NIC
 # performance data (but not too large, because each test will time out after 2 min).
-set(_download_url "https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.4.1/rocprofiler-systems-1.0.1-ubuntu-22.04-ROCm-60400-PAPI-OMPT-Python3.sh")
+set(_download_url
+    "https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.4.1/rocprofiler-systems-1.0.1-ubuntu-22.04-ROCm-60400-PAPI-OMPT-Python3.sh"
+    )
 
 # Run the NIC performance test
 add_test(

--- a/tests/rocprof-sys-nic-perf.cmake
+++ b/tests/rocprof-sys-nic-perf.cmake
@@ -50,7 +50,7 @@ set(_nic_perf_environment
 
 # Set _download_url to a large file that will give rocprof-sys-sample time to collect NIC
 # performance data (but not too large, because each test will time out after 2 min).
-set(_download_url "https://ftp.wayne.edu/gnu/gcc/gcc-15.1.0/gcc-14.2.0-15.1.0.diff.gz")
+set(_download_url "https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.4.1/rocprofiler-systems-1.0.1-ubuntu-22.04-ROCm-60400-PAPI-OMPT-Python3.sh")
 
 # Run the NIC performance test
 add_test(


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [ ] Closes #<issue number or link>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
Fixing ctest: on some systems, nic-performance was timing out because wget was downloading
a file that was too large.

## Have you added or updated tests to validate functionality?

- [x] Yes
- [ ] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
