### PR TITLE
Fix OMPT trace label name in Perfetto to prevent missing event confusion

### DIFF
--- a/source/lib/rocprof-sys/library.cpp
+++ b/source/lib/rocprof-sys/library.cpp
@@ -725,8 +725,6 @@ rocprofsys_finalize_hidden(void)
         }
     }
 
-    set_state(State::Finalized);
-
     push_enable_sampling_on_child_threads(false);
     set_sampling_on_all_future_threads(false);
 
@@ -887,6 +885,8 @@ rocprofsys_finalize_hidden(void)
             }
         }
     }
+
+    set_state(State::Finalized);
 
     ROCPROFSYS_VERBOSE_F(0, "\n");
 

--- a/source/lib/rocprof-sys/library/ompt.cpp
+++ b/source/lib/rocprof-sys/library/ompt.cpp
@@ -74,7 +74,7 @@ struct ompt : comp::base<ompt, void>
     ompt(const ompt&)     = default;
     ompt(ompt&&) noexcept = default;
 
-    ompt& operator=(const ompt&)     = default;
+    ompt& operator=(const ompt&) = default;
     ompt& operator=(ompt&&) noexcept = default;
 
     template <typename... Args>

--- a/source/lib/rocprof-sys/library/ompt.cpp
+++ b/source/lib/rocprof-sys/library/ompt.cpp
@@ -74,7 +74,7 @@ struct ompt : comp::base<ompt, void>
     ompt(const ompt&)     = default;
     ompt(ompt&&) noexcept = default;
 
-    ompt& operator=(const ompt&) = default;
+    ompt& operator=(const ompt&)     = default;
     ompt& operator=(ompt&&) noexcept = default;
 
     template <typename... Args>
@@ -97,13 +97,13 @@ struct ompt : comp::base<ompt, void>
         if(_cid > 0)
         {
             category_region<category::ompt>::start<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
+                (!m_prefix.empty()) ? m_prefix : _ctx_info.func, _ts,
                 ::perfetto::Flow::ProcessScoped(_cid), std::move(_annotate));
         }
         else
         {
             category_region<category::ompt>::start<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
+                (!m_prefix.empty()) ? m_prefix : _ctx_info.func, _ts,
                 std::move(_annotate));
         }
     }
@@ -128,13 +128,13 @@ struct ompt : comp::base<ompt, void>
         if(_cid > 0)
         {
             category_region<category::ompt>::stop<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
-                std::move(_annotate));
+                (!m_prefix.empty()) ? m_prefix : _ctx_info.func, _ts,
+                ::perfetto::Flow::ProcessScoped(_cid), std::move(_annotate));
         }
         else
         {
             category_region<category::ompt>::stop<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
+                (!m_prefix.empty()) ? m_prefix : _ctx_info.func, _ts,
                 std::move(_annotate));
         }
     }

--- a/source/lib/rocprof-sys/library/ompt.cpp
+++ b/source/lib/rocprof-sys/library/ompt.cpp
@@ -81,7 +81,6 @@ struct ompt : comp::base<ompt, void>
     void start(const context_info_t& _ctx_info, Args&&...) const
     {
         category_region<category::ompt>::start<tim::quirk::timemory>(m_prefix);
-
         auto     _ts = tracing::now();
         uint64_t _cid =
             (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
@@ -97,14 +96,13 @@ struct ompt : comp::base<ompt, void>
         if(_cid > 0)
         {
             category_region<category::ompt>::start<tim::quirk::perfetto>(
-                (!m_prefix.empty()) ? m_prefix : _ctx_info.func, _ts,
-                ::perfetto::Flow::ProcessScoped(_cid), std::move(_annotate));
+                _ctx_info.label, _ts, ::perfetto::Flow::ProcessScoped(_cid),
+                std::move(_annotate));
         }
         else
         {
             category_region<category::ompt>::start<tim::quirk::perfetto>(
-                (!m_prefix.empty()) ? m_prefix : _ctx_info.func, _ts,
-                std::move(_annotate));
+                _ctx_info.label, _ts, std::move(_annotate));
         }
     }
 
@@ -112,7 +110,6 @@ struct ompt : comp::base<ompt, void>
     void stop(const context_info_t& _ctx_info, Args&&...) const
     {
         category_region<category::ompt>::stop<tim::quirk::timemory>(m_prefix);
-
         auto     _ts = tracing::now();
         uint64_t _cid =
             (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
@@ -128,14 +125,13 @@ struct ompt : comp::base<ompt, void>
         if(_cid > 0)
         {
             category_region<category::ompt>::stop<tim::quirk::perfetto>(
-                (!m_prefix.empty()) ? m_prefix : _ctx_info.func, _ts,
-                ::perfetto::Flow::ProcessScoped(_cid), std::move(_annotate));
+                _ctx_info.label, _ts, ::perfetto::Flow::ProcessScoped(_cid),
+                std::move(_annotate));
         }
         else
         {
             category_region<category::ompt>::stop<tim::quirk::perfetto>(
-                (!m_prefix.empty()) ? m_prefix : _ctx_info.func, _ts,
-                std::move(_annotate));
+                _ctx_info.label, _ts, std::move(_annotate));
         }
     }
 
@@ -227,6 +223,16 @@ shutdown()
     static bool _protect = false;
     if(_protect) return;
     _protect = true;
+    pthread_gotcha::shutdown();
+    // call the OMPT finalize callback
+    if(f_finalize)
+    {
+        (*f_finalize)();
+        for(const auto& itr : tim::openmp::get_ompt_device_functions<api_t>())
+            if(itr.second.stop_trace) itr.second.stop_trace(itr.second.device);
+        f_finalize = nullptr;
+    }
+
     if(f_bundle)
     {
         if(tim::manager::instance()) tim::manager::instance()->cleanup("rocprofsys-ompt");
@@ -234,15 +240,6 @@ shutdown()
         ompt_context_t::cleanup();
         trait::runtime_enabled<ompt_toolset_t>::set(false);
         trait::runtime_enabled<ompt_context_t>::set(false);
-        pthread_gotcha::shutdown();
-        // call the OMPT finalize callback
-        if(f_finalize)
-        {
-            for(const auto& itr : tim::openmp::get_ompt_device_functions<api_t>())
-                if(itr.second.stop_trace) itr.second.stop_trace(itr.second.device);
-            (*f_finalize)();
-            f_finalize = nullptr;
-        }
     }
     f_bundle.reset();
     _protect = false;


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the issue(s) that this PR addresses.  -->
- [x] Closes # SWDEV-503210

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
This PR fixes a bug where the label name for OMP trace events in Perfetto was incorrect. The issue caused the traces to display the wrong label, which could lead to confusion and made it appear as though some events were missing

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
