### PR TITLE
Docker run command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ cd docker
 docker run -v "$(cd .. && pwd)":/home/development                                \
         -it -w /home/development                                                 \
         --device /dev/kfd --device /dev/dri                                      \
-        rocm/rocprofiler-systems:release-base-ubuntu-24.04-rocm-6.4
+        $(whoami)/rocprofiler-systems:release-base-ubuntu-24.04-rocm-6.4
 ```
 
 Inside the container, clean, build, and install the project with testing enabled using the following commands:


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
Fixes an issue with PR251.

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [x] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
In PR251, `rocm` is used as the username in the `docker run` command when it should be `$(whoami)`. 

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [x] Yes
- [ ] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
