### PR TITLE
SWDEV-504756 - Prevent the modification of interpreter directives (#168)

### DIFF
--- a/cmake/ConfigCPack.cmake
+++ b/cmake/ConfigCPack.cmake
@@ -219,7 +219,8 @@ string(REPLACE ";" ", " CPACK_RPM_PACKAGE_PROVIDES "${_RPM_PACKAGE_PROVIDES}")
 set(CPACK_RPM_PACKAGE_PROVIDES
     "${CPACK_RPM_PACKAGE_PROVIDES}"
     CACHE STRING "RPM package provides" FORCE)
-
+# Prevent the modification of python interpreter directives
+set(CPACK_RPM_SPEC_MORE_DEFINE "%undefine __brp_mangle_shebangs")
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
 set(CPACK_RPM_PACKAGE_RELEASE_DIST ON)


### PR DESCRIPTION
CPACK is converting /usr/bin/env python3 to /usr/libexec/platform-python in RHEL8. This is resulting in dependency to platform-python Undefining __brp_mangle_shebangs will prevent the same

# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [x] Closes SWDEV-540470

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [x] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
