### PR TITLE
Conditionally include backtraces in ROCPROFSYS_THROW based on verbosity

### DIFF
--- a/source/lib/core/debug.hpp
+++ b/source/lib/core/debug.hpp
@@ -377,14 +377,21 @@ as_hex<void*>(void*, size_t);
     if(ROCPROFSYS_UNLIKELY((COND)))                                                      \
     {                                                                                    \
         char _msg_buffer[ROCPROFSYS_DEBUG_BUFFER_LEN];                                   \
+        bool _print_backtrace = ::rocprofsys::get_debug() ||                             \
+                      ::rocprofsys::get_verbose() >= 2 ||                                \
+                      ::rocprofsys::get_is_continuous_integration();                     \
         snprintf(_msg_buffer, ROCPROFSYS_DEBUG_BUFFER_LEN,                               \
                  "[rocprof-sys][%i][%li][%s]%s", ROCPROFSYS_DEBUG_PROCESS_IDENTIFIER,    \
                  ROCPROFSYS_DEBUG_THREAD_IDENTIFIER, ROCPROFSYS_FUNCTION,                \
                  ::rocprofsys::debug::is_bracket(__VA_ARGS__) ? "" : " ");               \
         auto len = strlen(_msg_buffer);                                                  \
         snprintf(_msg_buffer + len, ROCPROFSYS_DEBUG_BUFFER_LEN - len, __VA_ARGS__);     \
-        throw ::rocprofsys::exception<TYPE>(                                             \
-            ::tim::log::string(::tim::log::color::fatal(), _msg_buffer));                \
+        if(!_print_backtrace)                                                            \
+            throw ::rocprofsys::exception<TYPE>(                                         \
+                ::tim::log::string(::tim::log::color::fatal(), _msg_buffer), false);     \
+        else                                                                             \
+            throw ::rocprofsys::exception<TYPE>(                                         \
+                ::tim::log::string(::tim::log::color::fatal(), _msg_buffer));            \
     }
 
 #define ROCPROFSYS_CONDITIONAL_BASIC_THROW_E(COND, TYPE, ...)                            \

--- a/source/lib/core/debug.hpp
+++ b/source/lib/core/debug.hpp
@@ -378,8 +378,8 @@ as_hex<void*>(void*, size_t);
     {                                                                                    \
         char _msg_buffer[ROCPROFSYS_DEBUG_BUFFER_LEN];                                   \
         bool _print_backtrace = ::rocprofsys::get_debug() ||                             \
-                      ::rocprofsys::get_verbose() >= 2 ||                                \
-                      ::rocprofsys::get_is_continuous_integration();                     \
+                                ::rocprofsys::get_verbose() >= 2 ||                      \
+                                ::rocprofsys::get_is_continuous_integration();           \
         snprintf(_msg_buffer, ROCPROFSYS_DEBUG_BUFFER_LEN,                               \
                  "[rocprof-sys][%i][%li][%s]%s", ROCPROFSYS_DEBUG_PROCESS_IDENTIFIER,    \
                  ROCPROFSYS_DEBUG_THREAD_IDENTIFIER, ROCPROFSYS_FUNCTION,                \

--- a/source/lib/core/exception.cpp
+++ b/source/lib/core/exception.cpp
@@ -74,6 +74,12 @@ exception<Tp>::exception(const char* _msg)
 {}
 
 template <typename Tp>
+exception<Tp>::exception(const std::string& _msg, bool with_backtrace)
+: Tp{ _msg }
+, m_what{ with_backtrace ? get_backtrace(_msg) : strdup(_msg.c_str()) }
+{}
+
+template <typename Tp>
 exception<Tp>::~exception()
 {
     free(m_what);

--- a/source/lib/core/exception.hpp
+++ b/source/lib/core/exception.hpp
@@ -36,6 +36,7 @@ class exception : public Tp
 public:
     explicit exception(const std::string& _msg);
     explicit exception(const char* _msg);
+    explicit exception(const std::string& _msg, bool with_backtrace);
 
     ~exception() override;
 


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [ ] Closes #<issue number>

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [x] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
Modify ROCPROFSYS_THROW to only include backtraces when:
  debug mode is enabled, OR
  verbose level is >= 2, OR
  running in CI environment

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
