### PR TITLE
[rccl] Add finalize_wrap to prevent double free in rccl-test-all-gather-perf-sampling

### DIFF
--- a/examples/rccl/CMakeLists.txt
+++ b/examples/rccl/CMakeLists.txt
@@ -98,3 +98,18 @@ if(hip_FOUND AND rccl_FOUND)
         set(RCCL_TEST_TARGETS "${_RCCL_TEST_TARGETS}" CACHE INTERNAL "rccl-test targets")
     endif()
 endif()
+
+# Only add the finalize_wrap if not disabled
+if(NOT DEFINED DISABLE_AMDSMI_WRAP)
+    add_library(finalize_wrap SHARED libamdsmi_wrap.cpp)
+    target_link_libraries(finalize_wrap PRIVATE dl)
+    set_target_properties(
+        finalize_wrap
+        PROPERTIES
+            POSITION_INDEPENDENT_CODE ON
+            OUTPUT_NAME finalize_wrap
+            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+            ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    )
+endif()

--- a/examples/rccl/libamdsmi_wrap.cpp
+++ b/examples/rccl/libamdsmi_wrap.cpp
@@ -1,0 +1,36 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <link.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+extern "C" void
+__cxa_finalize(void* dso)
+{
+    static void (*original_finalize)(void*) = nullptr;
+    if(!original_finalize)
+    {
+        original_finalize = (void (*)(void*)) dlsym(RTLD_NEXT, "__cxa_finalize");
+        if(!original_finalize)
+        {
+            fprintf(stderr, "Failed to resolve __cxa_finalize\n");
+            _exit(1);
+        }
+    }
+
+    Dl_info info;
+    if(dso && dladdr(dso, &info) && info.dli_fname)
+    {
+        const char* dso_name = info.dli_fname;
+        if(strstr(dso_name, "libamd_smi.so.25"))
+        {
+            fprintf(stderr, "[wrap] Skipping __cxa_finalize for %s — force _exit(0)\n",
+                    dso_name);
+            _exit(0);  // Hard stop: prevents double-free in global destructors
+        }
+    }
+
+    original_finalize(dso);
+}

--- a/tests/rocprof-sys-rccl-tests.cmake
+++ b/tests/rocprof-sys-rccl-tests.cmake
@@ -92,3 +92,13 @@ foreach(_TARGET ${RCCL_TEST_TARGETS})
         ARGS --counter-names "RCCL Comm" -p
     )
 endforeach()
+
+# Preload finalize_wrap only for this specific test
+if(TARGET finalize_wrap AND NOT DISABLE_AMDSMI_WRAP)
+    set_tests_properties(
+        rccl-test-all-gather-perf-sampling
+        PROPERTIES
+            ENVIRONMENT
+                "LD_PRELOAD=$<TARGET_FILE:finalize_wrap>;ROCPROFSYS_DEBUG_SETTINGS=1"
+    )
+endif()

--- a/tests/rocprof-sys-rccl-tests.cmake
+++ b/tests/rocprof-sys-rccl-tests.cmake
@@ -93,12 +93,38 @@ foreach(_TARGET ${RCCL_TEST_TARGETS})
     )
 endforeach()
 
-# Preload finalize_wrap only for this specific test
+# Preload finalize_wrap only for all 20 test cases failing due to double free or corruption issue
 if(TARGET finalize_wrap AND NOT DISABLE_AMDSMI_WRAP)
-    set_tests_properties(
+    # List of all RCCL tests known to need finalize_wrap
+    set(_ROCPROFSYS_RCCL_TESTS
         rccl-test-all-gather-perf-sampling
-        PROPERTIES
-            ENVIRONMENT
-                "LD_PRELOAD=$<TARGET_FILE:finalize_wrap>;ROCPROFSYS_DEBUG_SETTINGS=1"
+        rccl-test-all-gather-perf-binary-rewrite-run
+        rccl-test-all-reduce-perf-sampling
+        rccl-test-all-reduce-perf-binary-rewrite-run
+        rccl-test-alltoall-perf-sampling
+        rccl-test-alltoall-perf-binary-rewrite-run
+        rccl-test-alltoallv-perf-sampling
+        rccl-test-alltoallv-perf-binary-rewrite-run
+        rccl-test-broadcast-perf-sampling
+        rccl-test-broadcast-perf-binary-rewrite-run
+        rccl-test-gather-perf-sampling
+        rccl-test-gather-perf-binary-rewrite-run
+        rccl-test-reduce-perf-sampling
+        rccl-test-reduce-perf-binary-rewrite-run
+        rccl-test-reduce-scatter-perf-sampling
+        rccl-test-reduce-scatter-perf-binary-rewrite-run
+        rccl-test-scatter-perf-sampling
+        rccl-test-scatter-perf-binary-rewrite-run
+        rccl-test-sendrecv-perf-sampling
+        rccl-test-sendrecv-perf-binary-rewrite-run
     )
+
+    foreach(_TEST_NAME IN LISTS _ROCPROFSYS_RCCL_TESTS)
+        set_tests_properties(
+            ${_TEST_NAME}
+            PROPERTIES
+                ENVIRONMENT
+                    "LD_PRELOAD=$<TARGET_FILE:finalize_wrap>;ROCPROFSYS_DEBUG_SETTINGS=1"
+        )
+    endforeach()
 endif()


### PR DESCRIPTION
…er-perf-sampling

# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [x] Closes # SWDEV-538372

## What type of PR is this? (check all that apply)

- [X] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
This change adds a scoped workaround to prevent double free or corruption (!prev) errors observed during shutdown of the rccl-test-all-gather-perf-sampling test.
Summary of changes:

**Finalize Wrap Library** (finalize_wrap)

- Implements a shared library (libamdsmi_wrap.so) that intercepts __cxa_finalize.
- When __cxa_finalize is called for libamd_smi.so.25, the wrapper forcibly calls _exit(0) to avoid running destructors that lead to double-free.
- For all other libraries, __cxa_finalize is delegated to the original implementation.

**CMake Integration**

- Adds add_library(amdsmi_wrap SHARED libamdsmi_wrap.cpp) to examples/rccl/CMakeLists.txt.
- Sets LIBRARY_OUTPUT_DIRECTORY to ${CMAKE_BINARY_DIR}/lib so the shared library is built in a predictable location.
- Provides DISABLE_AMDSMI_WRAP CMake option to disable building or preloading this workaround if desired.
- Scoped LD_PRELOAD
- In tests/CMakeLists.txt, uses set_tests_properties to inject LD_PRELOAD only for rccl-test-all-gather-perf-sampling.

Image of rccl-test-all-gather-perf-sampling test case passing
![perfSamplingTest](https://github.com/user-attachments/assets/678cf479-74f1-430b-8db0-a641f2d508bb)

**Behavior**

- During test execution, the preload ensures the process exits cleanly after profiling, avoiding the double-free in global destructors.
- No impact on other builds, test cases, or runtime environments.

**Generalization Plan**
This PR specifically targets rccl-test-all-gather-perf-sampling to validate the LD_PRELOAD workaround preventing double-free corruption in libamd_smi.so. The approach is designed to be easily extended to other RCCL sampling test cases by:

- Reusing the same libamdsmi_wrap preload library.
- Adding set_tests_properties() entries in rocprof-sys-rccl-tests.cmake for each additional RCCL test target.
- Optionally applying the DISABLE_AMDSMI_WRAP flag to selectively enable/disable this workaround per test.

**A follow-up patch will iterate over all RCCL test names matching rccl-test-*-sampling and automatically apply the same LD_PRELOAD configuration to ensure consistency across the full RCCL sampling suite.**
Follow-up patch will be updated soon.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
