### PR TITLE
Fix ROCtx Traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - Fixed a build issue with CMake 4.
 - Fixed incorrect kernel names shown for kernel dispatch tracks in Perfetto.
 - Fixed formatting of some output logs.
-- Fixed an issue where ROC-TX ranges were displayed as two separate events instead of a single spanning event
+- Fixed an issue where ROC-TX ranges were displayed as two separate events instead of a single spanning event.
 
 ## ROCm Systems Profiler 1.0.2 for ROCm 6.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - Fixed a build issue with CMake 4.
 - Fixed incorrect kernel names shown for kernel dispatch tracks in Perfetto.
 - Fixed formatting of some output logs.
+- Fixed an issue where ROC-TX ranges were displayed as two separate events instead of a single spanning event
 
 ## ROCm Systems Profiler 1.0.2 for ROCm 6.4.2
 

--- a/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -256,18 +256,14 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
                 {
                     _name      = _data->args.roctxRangePushA.message;
                     auto _hash = tim::add_hash_id(_name);
-                    std::pair<tim::hash_value_t, rocprofiler_timestamp_t> _rangePush(
-                        _hash, ts);
-                    get_marker_pushed_ranges().emplace_back(_rangePush);
+                    get_marker_pushed_ranges().emplace_back(_hash, ts);
                     break;
                 }
                 case ROCPROFILER_MARKER_CORE_API_ID_roctxRangeStartA:
                 {
                     _name      = _data->args.roctxRangeStartA.message;
                     auto _hash = tim::add_hash_id(_name);
-                    std::pair<tim::hash_value_t, rocprofiler_timestamp_t> _rangeStart(
-                        _hash, ts);
-                    get_marker_started_ranges().emplace_back(_rangeStart);
+                    get_marker_started_ranges().emplace_back(_hash, ts);
                     break;
                 }
                 case ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA:

--- a/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -241,6 +241,10 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
                             rocprofiler_user_data_t* /*user_data*/,
                             rocprofiler_timestamp_t ts)
 {
+    // Required because of how some compilers handle templates. This may result in an
+    // "unused variable" warning.
+    (void) ts;
+
     auto _name = tool_data->callback_tracing_info.at(record.kind, record.operation);
 
     if constexpr(std::is_same<CategoryT, category::rocm_marker_api>::value)

--- a/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -222,14 +222,16 @@ save_args(rocprofiler_callback_tracing_kind_t /*kind*/, int32_t /*operation*/,
 auto&
 get_marker_pushed_ranges()
 {
-    static thread_local auto _v = std::vector<std::pair <tim::hash_value_t, rocprofiler_timestamp_t>>{};
+    static thread_local auto _v =
+        std::vector<std::pair<tim::hash_value_t, rocprofiler_timestamp_t>>{};
     return _v;
 }
 
 auto&
 get_marker_started_ranges()
 {
-    static thread_local auto _v = std::vector<std::pair <tim::hash_value_t, rocprofiler_timestamp_t>>{};
+    static thread_local auto _v =
+        std::vector<std::pair<tim::hash_value_t, rocprofiler_timestamp_t>>{};
     return _v;
 }
 
@@ -254,7 +256,8 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
                 {
                     _name      = _data->args.roctxRangePushA.message;
                     auto _hash = tim::add_hash_id(_name);
-                    std::pair <tim::hash_value_t, rocprofiler_timestamp_t> _rangePush (_hash, ts);
+                    std::pair<tim::hash_value_t, rocprofiler_timestamp_t> _rangePush(
+                        _hash, ts);
                     get_marker_pushed_ranges().emplace_back(_rangePush);
                     break;
                 }
@@ -262,7 +265,8 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
                 {
                     _name      = _data->args.roctxRangeStartA.message;
                     auto _hash = tim::add_hash_id(_name);
-                    std::pair <tim::hash_value_t, rocprofiler_timestamp_t> _rangeStart (_hash, ts);
+                    std::pair<tim::hash_value_t, rocprofiler_timestamp_t> _rangeStart(
+                        _hash, ts);
                     get_marker_started_ranges().emplace_back(_rangeStart);
                     break;
                 }
@@ -310,11 +314,12 @@ tool_tracing_callback_stop(
                 {
                     ROCPROFSYS_CONDITIONAL_ABORT_F(
                         get_marker_pushed_ranges().empty(),
-                        "roctxRangePop does not have corresponding roctxRangePush on this thread");
+                        "roctxRangePop does not have corresponding roctxRangePush on "
+                        "this thread");
 
                     auto _hash = get_marker_pushed_ranges().back().first;
                     _name      = tim::get_hash_identifier_fast(_hash);
-                    begin_ts = get_marker_pushed_ranges().back().second;
+                    begin_ts   = get_marker_pushed_ranges().back().second;
                     get_marker_pushed_ranges().pop_back();
                     break;
                 }
@@ -322,11 +327,12 @@ tool_tracing_callback_stop(
                 {
                     ROCPROFSYS_CONDITIONAL_ABORT_F(
                         get_marker_started_ranges().empty(),
-                        "roctxRangeStop does not have corresponding roctxRangeStart on this thread");
+                        "roctxRangeStop does not have corresponding roctxRangeStart on "
+                        "this thread");
 
                     auto _hash = get_marker_started_ranges().back().first;
                     _name      = tim::get_hash_identifier_fast(_hash);
-                    begin_ts = get_marker_started_ranges().back().second;
+                    begin_ts   = get_marker_started_ranges().back().second;
                     get_marker_started_ranges().pop_back();
                     break;
                 }

--- a/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -341,9 +341,14 @@ tool_tracing_callback_stop(
                     _name = _data->args.roctxMarkA.message;
                     break;
                 }
-                default:
+                case ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA:
+                case ROCPROFILER_MARKER_CORE_API_ID_roctxRangeStartA:
                 {
                     return;
+                }
+                default:
+                {
+                    break;
                 }
             }
         }

--- a/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -222,14 +222,14 @@ save_args(rocprofiler_callback_tracing_kind_t /*kind*/, int32_t /*operation*/,
 auto&
 get_marker_pushed_ranges()
 {
-    static thread_local auto _v = std::vector<tim::hash_value_t>{};
+    static thread_local auto _v = std::vector<std::pair <tim::hash_value_t, rocprofiler_timestamp_t>>{};
     return _v;
 }
 
 auto&
 get_marker_started_ranges()
 {
-    static thread_local auto _v = std::vector<tim::hash_value_t>{};
+    static thread_local auto _v = std::vector<std::pair <tim::hash_value_t, rocprofiler_timestamp_t>>{};
     return _v;
 }
 
@@ -237,7 +237,7 @@ template <typename CategoryT>
 void
 tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t record,
                             rocprofiler_user_data_t* /*user_data*/,
-                            rocprofiler_timestamp_t /*ts*/)
+                            rocprofiler_timestamp_t ts)
 {
     auto _name = tool_data->callback_tracing_info.at(record.kind, record.operation);
 
@@ -254,14 +254,16 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
                 {
                     _name      = _data->args.roctxRangePushA.message;
                     auto _hash = tim::add_hash_id(_name);
-                    get_marker_pushed_ranges().emplace_back(_hash);
+                    std::pair <tim::hash_value_t, rocprofiler_timestamp_t> _rangePush (_hash, ts);
+                    get_marker_pushed_ranges().emplace_back(_rangePush);
                     break;
                 }
                 case ROCPROFILER_MARKER_CORE_API_ID_roctxRangeStartA:
                 {
                     _name      = _data->args.roctxRangeStartA.message;
                     auto _hash = tim::add_hash_id(_name);
-                    get_marker_started_ranges().emplace_back(_hash);
+                    std::pair <tim::hash_value_t, rocprofiler_timestamp_t> _rangeStart (_hash, ts);
+                    get_marker_started_ranges().emplace_back(_rangeStart);
                     break;
                 }
                 case ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA:
@@ -294,6 +296,7 @@ tool_tracing_callback_stop(
 {
     auto _name = tool_data->callback_tracing_info.at(record.kind, record.operation);
 
+    uint64_t begin_ts = user_data->value;
     if constexpr(std::is_same<CategoryT, category::rocm_marker_api>::value)
     {
         if(record.kind == ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API)
@@ -307,11 +310,11 @@ tool_tracing_callback_stop(
                 {
                     ROCPROFSYS_CONDITIONAL_ABORT_F(
                         get_marker_pushed_ranges().empty(),
-                        "roctxRangePop does not have corresponding roctxRangePush on "
-                        "this thread");
+                        "roctxRangePop does not have corresponding roctxRangePush on this thread");
 
-                    auto _hash = get_marker_pushed_ranges().back();
+                    auto _hash = get_marker_pushed_ranges().back().first;
                     _name      = tim::get_hash_identifier_fast(_hash);
+                    begin_ts = get_marker_pushed_ranges().back().second;
                     get_marker_pushed_ranges().pop_back();
                     break;
                 }
@@ -319,11 +322,11 @@ tool_tracing_callback_stop(
                 {
                     ROCPROFSYS_CONDITIONAL_ABORT_F(
                         get_marker_started_ranges().empty(),
-                        "roctxRangeStop does not have corresponding roctxRangeStart on "
-                        "this thread");
+                        "roctxRangeStop does not have corresponding roctxRangeStart on this thread");
 
-                    auto _hash = get_marker_started_ranges().back();
+                    auto _hash = get_marker_started_ranges().back().first;
                     _name      = tim::get_hash_identifier_fast(_hash);
+                    begin_ts = get_marker_started_ranges().back().second;
                     get_marker_started_ranges().pop_back();
                     break;
                 }
@@ -334,7 +337,7 @@ tool_tracing_callback_stop(
                 }
                 default:
                 {
-                    break;
+                    return;
                 }
             }
         }
@@ -355,7 +358,7 @@ tool_tracing_callback_stop(
                                                                      &args);
         }
 
-        uint64_t _beg_ts = user_data->value;
+        uint64_t _beg_ts = begin_ts;
         uint64_t _end_ts = ts;
 
         tracing::push_perfetto_ts(
@@ -1396,3 +1399,4 @@ rocprofiler_configure(uint32_t version, const char* runtime_version, uint32_t pr
     // return pointer to configure data
     return &cfg;
 }
+

--- a/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -1399,4 +1399,3 @@ rocprofiler_configure(uint32_t version, const char* runtime_version, uint32_t pr
     // return pointer to configure data
     return &cfg;
 }
-

--- a/tests/rocprof-sys-roctx-tests.cmake
+++ b/tests/rocprof-sys-roctx-tests.cmake
@@ -39,27 +39,19 @@ rocprofiler_systems_add_test(
 )
 set(ROCTX_LABEL
     roctxMark_GPU_workload
-    roctxRangePushA
-    roctxRangePushA
-    roctxRangeStartA
-    roctxRangeStartA
-    roctxRangePush_HIP_Kernel
-    roctxRangePush_HIP_Kernel
+    roctxRangePush_run_profiling
     roctxRangeStart_GPU_Compute
     roctxRangeStart_GPU_Compute
+    roctxRangePush_HIP_Kernel
+    roctxRangePush_HIP_Kernel
     roctxGetThreadId
     roctxMark_RoctxProfilerPause_End
     roctxMark_Thread_Start
     roctxMark_End
-    roctxRangePush_run_profiling
     roctxMark_Finished_GPU
 )
 
 set(ROCTX_COUNT
-    1
-    2
-    1
-    1
     1
     1
     1
@@ -76,18 +68,14 @@ set(ROCTX_COUNT
 set(ROCTX_DEPTH
     1
     1
+    2
     0
+    3
     1
-    0
-    1
-    0
-    1
-    0
-    1
-    1
+    2
+    2
     0
     0
-    1
     1
 )
 


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [x] Closes https://github.com/ROCm/rocprofiler-systems/issues/266, SWDEV-529209

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
Changed the logic for the starting timestamp of a roctx event. Also made it so the event spans from rangeStart to rangeEnd instead of having two separate events.

## Have you added or updated tests to validate functionality?

- [x] Yes
- [ ] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [x] Yes
- [ ] No - does not apply to this PR
