### PR TITLE
Fix: Add missing <string.h> include for C string functions in RCCL tests

### DIFF
--- a/examples/rccl/rccl-tests/src/common.h
+++ b/examples/rccl/rccl-tests/src/common.h
@@ -17,10 +17,10 @@
 #endif
 #include "nccl1_compat.h"
 #include "timer.h"
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <pthread.h>
-#include <cstring>
 // Ensures backward compatibility for FP8 types in RCCL 2.24.3 and later
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 24, 3)
 #    define ncclFp8E4M3 ncclFloat8e4m3

--- a/examples/rccl/rccl-tests/src/common.h
+++ b/examples/rccl/rccl-tests/src/common.h
@@ -20,8 +20,7 @@
 #include <fstream>
 #include <iostream>
 #include <pthread.h>
-#include <string.h>
-#include <string>
+#include <cstring>
 // Ensures backward compatibility for FP8 types in RCCL 2.24.3 and later
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 24, 3)
 #    define ncclFp8E4M3 ncclFloat8e4m3

--- a/examples/rccl/rccl-tests/src/common.h
+++ b/examples/rccl/rccl-tests/src/common.h
@@ -20,8 +20,8 @@
 #include <fstream>
 #include <iostream>
 #include <pthread.h>
+#include <string.h>
 #include <string>
-
 // Ensures backward compatibility for FP8 types in RCCL 2.24.3 and later
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 24, 3)
 #    define ncclFp8E4M3 ncclFloat8e4m3


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [x] Closes #SWDEV-543197

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
The common.h header uses C string functions:
- strncpy
- strlen
- strcmp

but only included <string>, which provides std::string but does not declare the C APIs.
This resulted in errors like:
  error: use of undeclared identifier 'strncpy'
  
## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
