### PR TITLE
Check system executable path validity to avoid codeQL error

### DIFF
--- a/source/lib/core/perfetto.cpp
+++ b/source/lib/core/perfetto.cpp
@@ -278,6 +278,13 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error)
         auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
         auto _script_dir    = get_env("ROCPROFSYS_SCRIPT_PATH", std::string{}, false);
 
+        // Validate path - only allow absolute paths within expected directories
+        if (_script_dir.empty() || _script_dir[0] != '/' || 
+            _script_dir.find("..") != std::string::npos ||
+            _script_dir.find("libexec/rocprofiler-systems") == std::string::npos) {
+            _script_dir.clear(); // Invalid path, set to empty string
+        }
+
         if(!_script_dir.empty())
         {
             _script_path = rocprofsys::common::join("/", _script_dir, _script_path);

--- a/source/lib/core/perfetto.cpp
+++ b/source/lib/core/perfetto.cpp
@@ -279,11 +279,11 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error)
         auto _script_dir    = get_env("ROCPROFSYS_SCRIPT_PATH", std::string{}, false);
 
         // Validate path - only allow absolute paths within expected directories
-        if (_script_dir.empty() || _script_dir[0] != '/' || 
-            _script_dir.find("..") != std::string::npos ||
-            _script_dir.find("libexec/rocprofiler-systems") == std::string::npos) 
+        if(_script_dir.empty() || _script_dir[0] != '/' ||
+           _script_dir.find("..") != std::string::npos ||
+           _script_dir.find("libexec/rocprofiler-systems") == std::string::npos)
         {
-            _script_dir.clear(); // Invalid path, set to empty string
+            _script_dir.clear();  // Invalid path, set to empty string
         }
 
         if(!_script_dir.empty())

--- a/source/lib/core/perfetto.cpp
+++ b/source/lib/core/perfetto.cpp
@@ -281,7 +281,8 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error)
         // Validate path - only allow absolute paths within expected directories
         if (_script_dir.empty() || _script_dir[0] != '/' || 
             _script_dir.find("..") != std::string::npos ||
-            _script_dir.find("libexec/rocprofiler-systems") == std::string::npos) {
+            _script_dir.find("libexec/rocprofiler-systems") == std::string::npos) 
+        {
             _script_dir.clear(); // Invalid path, set to empty string
         }
 


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [x] Closes #SWDEV-533590

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
Environment variable is used to pass executable script path between different processes with separate memory spaces. CodeQL flagged this as an error as it assumes that the environment variable is set by the user and the user could inject commands through this variable. I added a validation logic to ensure that the CodeQL false flag is suppressed as this environment variable is set by the program and not the user and even if set the value will be overwritten by the program logic before execution thus it is safe.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
