### PR TITLE
Fix to find MPI symbols from undefined symbols

### DIFF
--- a/source/bin/rocprof-sys-instrument/details.cpp
+++ b/source/bin/rocprof-sys-instrument/details.cpp
@@ -516,7 +516,7 @@ find_undefined_function_symbol(image_t* app_image, const std::string& _name)
 
         for(auto* symbol : all_symbols)
         {
-            if(!symbol) continue;
+            if (!symbol || symbol->getType() != SymTab::Symbol::ST_FUNCTION || symbol->getRegion()) continue;
 
             // Try all possible symbol name representations
             std::string symbol_name = symbol->getPrettyName();
@@ -524,12 +524,8 @@ find_undefined_function_symbol(image_t* app_image, const std::string& _name)
             if(symbol_name.empty()) symbol_name = symbol->getTypedName();
 
             // Check for exact match and undefined function criteria
-            if(symbol_name == target_name &&
-               symbol->getType() == SymTab::Symbol::ST_FUNCTION &&
-               symbol->getRegion() == nullptr)
-            {
+            if (symbol_name == target_name)
                 return symbol;
-            }
         }
         return nullptr;
     };

--- a/source/bin/rocprof-sys-instrument/details.cpp
+++ b/source/bin/rocprof-sys-instrument/details.cpp
@@ -516,7 +516,9 @@ find_undefined_function_symbol(image_t* app_image, const std::string& _name)
 
         for(auto* symbol : all_symbols)
         {
-            if (!symbol || symbol->getType() != SymTab::Symbol::ST_FUNCTION || symbol->getRegion()) continue;
+            if(!symbol || symbol->getType() != SymTab::Symbol::ST_FUNCTION ||
+               symbol->getRegion())
+                continue;
 
             // Try all possible symbol name representations
             std::string symbol_name = symbol->getPrettyName();
@@ -524,8 +526,7 @@ find_undefined_function_symbol(image_t* app_image, const std::string& _name)
             if(symbol_name.empty()) symbol_name = symbol->getTypedName();
 
             // Check for exact match and undefined function criteria
-            if (symbol_name == target_name)
-                return symbol;
+            if(symbol_name == target_name) return symbol;
         }
         return nullptr;
     };

--- a/source/bin/rocprof-sys-instrument/details.cpp
+++ b/source/bin/rocprof-sys-instrument/details.cpp
@@ -490,6 +490,80 @@ find_function(image_t* app_image, const std::string& _name, const strset_t& _ext
 
 //======================================================================================//
 //
+//  Find undefined function symbols (external references) in the binary
+//
+symtab_symbol_t*
+find_undefined_function_symbol(image_t* app_image, const std::string& _name)
+{
+    if(_name.empty()) return nullptr;
+
+    // Get all objects from the image
+    BPatch_Vector<BPatch_object*> app_objects;
+    app_image->getObjects(app_objects);
+
+    if(app_objects.empty())
+    {
+        verbprintf(3, "No objects found in image for symbol search\n");
+        return nullptr;
+    }
+    // Search helper lambda for code reuse
+    auto _find_symbol = [](SymTab::Symtab*    symtab,
+                           const std::string& target_name) -> symtab_symbol_t* {
+        if(!symtab) return nullptr;
+
+        std::vector<SymTab::Symbol*> all_symbols;
+        if(!symtab->getAllSymbols(all_symbols)) return nullptr;
+
+        for(auto* symbol : all_symbols)
+        {
+            if(!symbol) continue;
+
+            // Try all possible symbol name representations
+            std::string symbol_name = symbol->getPrettyName();
+            if(symbol_name.empty()) symbol_name = symbol->getMangledName();
+            if(symbol_name.empty()) symbol_name = symbol->getTypedName();
+
+            // Check for exact match and undefined function criteria
+            if(symbol_name == target_name &&
+               symbol->getType() == SymTab::Symbol::ST_FUNCTION &&
+               symbol->getRegion() == nullptr)
+            {
+                return symbol;
+            }
+        }
+        return nullptr;
+    };
+
+    // Search through each object
+    for(auto* app_object : app_objects)
+    {
+        if(!app_object) continue;
+
+        std::string binary_path = app_object->name();
+        // Open Symtab directly for comprehensive symbol access
+        SymTab::Symtab* symtab = nullptr;
+        if(!SymTab::Symtab::openFile(symtab, binary_path))
+        {
+            verbprintf(3, "Failed to open Symtab for: %s\n", binary_path.c_str());
+            continue;
+        }
+
+        // Search for the primary symbol name
+        auto* result = _find_symbol(symtab, _name);
+        if(result)
+        {
+            verbprintf(1, "Found undefined function symbol: '%s' in %s\n", _name.c_str(),
+                       binary_path.c_str());
+            return result;
+        }
+    }
+
+    verbprintf(1, "Undefined function symbol: '%s' ... not found\n", _name.c_str());
+    return nullptr;
+}
+
+//======================================================================================//
+//
 //  Get the realpath to this exe
 //
 bool

--- a/source/bin/rocprof-sys-instrument/fwd.hpp
+++ b/source/bin/rocprof-sys-instrument/fwd.hpp
@@ -360,6 +360,9 @@ insert_instr(address_space_t* mutatee, Tp traceFunc, procedure_loc_t traceLoc,
 procedure_t*
 find_function(image_t* appImage, const string_t& functionName, const strset_t& = {});
 
+symtab_symbol_t*
+find_undefined_function_symbol(image_t* app_image, const std::string& _name);
+
 void
 error_func_real(error_level_t level, int num, const char* const* params);
 

--- a/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -1721,6 +1721,14 @@ main(int argc, char** argv)
             use_mpi = true;
             break;
         }
+        else if(find_undefined_function_symbol(app_image, itr) != nullptr)
+        {
+            verbprintf(0,
+                       "Found undefined symbol '%s' in '%s'. Enabling MPI support...\n",
+                       itr, _cmdv[0]);
+            use_mpi = true;
+            break;
+        }
     }
 #endif
 


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [x] Closes # SWDEV-511628

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
On Ubuntu 24 the auto detection of MPI functions are failing. The find_function is unable to detect the symbols.
The symbol MPI_Init_thread exists in the binary, but Dyninst doesn't recognize it as a function. 

The symbol is present in the symbol table (nm -D shows it)
But it's not marked as a function type in the ELF metadata

The sym->isFunction() returns false, sym->getRegion() returns nullptr and sym->getType() returns Symbol::ST_FUNCTION.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
