### PR TITLE
Fix Fortran OMPT labels for Perfetto

### DIFF
--- a/source/lib/rocprof-sys/library/ompt.cpp
+++ b/source/lib/rocprof-sys/library/ompt.cpp
@@ -82,7 +82,9 @@ struct ompt : comp::base<ompt, void>
     {
         category_region<category::ompt>::start<tim::quirk::timemory>(_ctx_info.label);
 
-        auto _ts       = tracing::now();
+        auto     _ts = tracing::now();
+        uint64_t _cid =
+            (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
         auto _annotate = [&](::perfetto::EventContext ctx) {
             if(config::get_perfetto_annotations())
             {
@@ -92,8 +94,17 @@ struct ompt : comp::base<ompt, void>
             }
         };
 
-        category_region<category::ompt>::start<tim::quirk::perfetto>(
-            _ctx_info.label, _ts, std::move(_annotate));
+        if(_cid > 0)
+        {
+            category_region<category::ompt>::start<tim::quirk::perfetto>(
+                _ctx_info.label, _ts, ::perfetto::Flow::ProcessScoped(_cid),
+                std::move(_annotate));
+        }
+        else
+        {
+            category_region<category::ompt>::start<tim::quirk::perfetto>(
+                _ctx_info.label, _ts, std::move(_annotate));
+        }
     }
 
     template <typename... Args>

--- a/source/lib/rocprof-sys/library/ompt.cpp
+++ b/source/lib/rocprof-sys/library/ompt.cpp
@@ -80,11 +80,9 @@ struct ompt : comp::base<ompt, void>
     template <typename... Args>
     void start(const context_info_t& _ctx_info, Args&&...) const
     {
-        category_region<category::ompt>::start<tim::quirk::timemory>(m_prefix);
+        category_region<category::ompt>::start<tim::quirk::timemory>(_ctx_info.label);
 
-        auto     _ts = tracing::now();
-        uint64_t _cid =
-            (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
+        auto _ts       = tracing::now();
         auto _annotate = [&](::perfetto::EventContext ctx) {
             if(config::get_perfetto_annotations())
             {
@@ -94,28 +92,16 @@ struct ompt : comp::base<ompt, void>
             }
         };
 
-        if(_cid > 0)
-        {
-            category_region<category::ompt>::start<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
-                ::perfetto::Flow::ProcessScoped(_cid), std::move(_annotate));
-        }
-        else
-        {
-            category_region<category::ompt>::start<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
-                std::move(_annotate));
-        }
+        category_region<category::ompt>::start<tim::quirk::perfetto>(
+            _ctx_info.label, _ts, std::move(_annotate));
     }
 
     template <typename... Args>
     void stop(const context_info_t& _ctx_info, Args&&...) const
     {
-        category_region<category::ompt>::stop<tim::quirk::timemory>(m_prefix);
+        category_region<category::ompt>::stop<tim::quirk::timemory>(_ctx_info.label);
 
-        auto     _ts = tracing::now();
-        uint64_t _cid =
-            (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
+        auto _ts       = tracing::now();
         auto _annotate = [&](::perfetto::EventContext ctx) {
             if(config::get_perfetto_annotations())
             {
@@ -125,18 +111,8 @@ struct ompt : comp::base<ompt, void>
             }
         };
 
-        if(_cid > 0)
-        {
-            category_region<category::ompt>::stop<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
-                std::move(_annotate));
-        }
-        else
-        {
-            category_region<category::ompt>::stop<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
-                std::move(_annotate));
-        }
+        category_region<category::ompt>::stop<tim::quirk::perfetto>(_ctx_info.label, _ts,
+                                                                    std::move(_annotate));
     }
 
     template <typename... Args>


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [ ] Closes 545224

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->
 - Switched to using `_ctx_info.label` for the perfetto track names in `ompt.cpp`. This gets rid of the `QQMain` and `@ QQMain` naming. 
- Removed redundant `if (_cid)` check in `stop`.
- Flow events are to be updated in future PR.

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
