### PR TITLE
Extract correct gpu type for smi power metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/).
 
+## ROCm System Profiler 1.2.0
+
+### Resolved issues
+
+- Fix incorrect power readings for pre-MI300 GPUs. 
+
 ## ROCm Systems Profiler 1.1.0 for ROCm 7.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 
 ### Resolved issues
 
-- Fix incorrect power readings for pre-MI300 GPUs. 
+- Fix incorrect power readings for pre-MI300 GPUs.
 
 ## ROCm Systems Profiler 1.1.0 for ROCm 7.0
 

--- a/source/lib/core/gpu.cpp
+++ b/source/lib/core/gpu.cpp
@@ -250,7 +250,7 @@ std::vector<bool>                    processors::vcn_activity_supported  = {};
 std::vector<bool>                    processors::jpeg_activity_supported = {};
 std::vector<bool>                    processors::vcn_busy_supported      = {};
 std::vector<bool>                    processors::jpeg_busy_supported     = {};
-std::vector<bool>                    processors::gpu_category_mi300      = {};
+std::vector<bool>                    processors::current_power_supported = {};
 
 void
 get_processor_handles()
@@ -300,7 +300,7 @@ get_processor_handles()
             amdsmi_asic_info_t   asic_info;
             bool                 vcn_supported = false, jpeg_supported = false;
             bool                 v_busy_supported = false, j_busy_supported = false;
-            bool                 gpu_cat_mi300 = false;
+            bool                 current_power_supported = false;
             // AMD SMI will not report VCN_activity and JPEG_activity, if VCN_busy or
             // JPEG_busy fields are available.
             if(amdsmi_get_gpu_metrics_info(processor, &gpu_metrics) ==
@@ -329,14 +329,14 @@ get_processor_handles()
 
                 if(gfx_version >= mi300_gfx_ver && gfx_version < navi10_gfx_ver)
                 {
-                    gpu_cat_mi300 = true;
+                    current_power_supported = true;
                 }
             }
             processors::vcn_activity_supported.push_back(vcn_supported);
             processors::jpeg_activity_supported.push_back(jpeg_supported);
             processors::vcn_busy_supported.push_back(v_busy_supported);
             processors::jpeg_busy_supported.push_back(j_busy_supported);
-            processors::gpu_category_mi300.push_back(gpu_cat_mi300);
+            processors::current_power_supported.push_back(current_power_supported);
         }
     }
     processors::total_processor_count = processors::processors_list.size();
@@ -383,10 +383,10 @@ get_handle_from_id(uint32_t dev_id)
 }
 
 bool
-is_gpu_category_mi300(uint32_t dev_id)
+is_current_power_supported(uint32_t dev_id)
 {
-    if(dev_id >= processors::gpu_category_mi300.size()) return false;
-    return processors::gpu_category_mi300[dev_id];
+    if(dev_id >= processors::current_power_supported.size()) return false;
+    return processors::current_power_supported[dev_id];
 }
 
 #endif

--- a/source/lib/core/gpu.hpp
+++ b/source/lib/core/gpu.hpp
@@ -31,6 +31,10 @@ namespace rocprofsys
 namespace gpu
 {
 #if ROCPROFSYS_USE_ROCM > 0
+
+constexpr uint64_t mi300_gfx_ver  = 0x940;
+constexpr uint64_t navi10_gfx_ver = 0x1010;
+
 void
 get_processor_handles();
 
@@ -52,6 +56,9 @@ is_vcn_busy_supported(uint32_t dev_id);
 bool
 is_jpeg_busy_supported(uint32_t dev_id);
 
+bool
+is_gpu_category_mi300(uint32_t dev_id);
+
 struct processors
 {
     static uint32_t                             total_processor_count;
@@ -60,6 +67,7 @@ struct processors
     static std::vector<bool>                    jpeg_activity_supported;
     static std::vector<bool>                    vcn_busy_supported;
     static std::vector<bool>                    jpeg_busy_supported;
+    static std::vector<bool>                    gpu_category_mi300;
 
 private:
     friend void                    rocprofsys::gpu::get_processor_handles();
@@ -69,6 +77,7 @@ private:
     friend bool rocprofsys::gpu::is_jpeg_activity_supported(uint32_t dev_id);
     friend bool rocprofsys::gpu::is_vcn_busy_supported(uint32_t dev_id);
     friend bool rocprofsys::gpu::is_jpeg_busy_supported(uint32_t dev_id);
+    friend bool rocprofsys::gpu::is_gpu_category_mi300(uint32_t dev_id);
 };
 #endif
 

--- a/source/lib/core/gpu.hpp
+++ b/source/lib/core/gpu.hpp
@@ -57,7 +57,7 @@ bool
 is_jpeg_busy_supported(uint32_t dev_id);
 
 bool
-is_gpu_category_mi300(uint32_t dev_id);
+is_current_power_supported(uint32_t dev_id);
 
 struct processors
 {
@@ -67,7 +67,7 @@ struct processors
     static std::vector<bool>                    jpeg_activity_supported;
     static std::vector<bool>                    vcn_busy_supported;
     static std::vector<bool>                    jpeg_busy_supported;
-    static std::vector<bool>                    gpu_category_mi300;
+    static std::vector<bool>                    current_power_supported;
 
 private:
     friend void                    rocprofsys::gpu::get_processor_handles();
@@ -77,7 +77,7 @@ private:
     friend bool rocprofsys::gpu::is_jpeg_activity_supported(uint32_t dev_id);
     friend bool rocprofsys::gpu::is_vcn_busy_supported(uint32_t dev_id);
     friend bool rocprofsys::gpu::is_jpeg_busy_supported(uint32_t dev_id);
-    friend bool rocprofsys::gpu::is_gpu_category_mi300(uint32_t dev_id);
+    friend bool rocprofsys::gpu::is_current_power_supported(uint32_t dev_id);
 };
 #endif
 

--- a/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -500,7 +500,9 @@ data::post_process(uint32_t _dev_id)
         double _umcbusy = itr.m_busy_perc.umc_activity;
         double _mmbusy  = itr.m_busy_perc.mm_activity;
         double _temp    = itr.m_temp;
-        double _power   = itr.m_power.current_socket_power;
+        double _power   = gpu::is_gpu_category_mi300(_dev_id)
+                              ? itr.m_power.current_socket_power
+                              : itr.m_power.average_socket_power;
         double _usage   = itr.m_mem_usage / static_cast<double>(units::megabyte);
 
         auto setup_perfetto_counter_tracks = [&]() {

--- a/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -500,7 +500,7 @@ data::post_process(uint32_t _dev_id)
         double _umcbusy = itr.m_busy_perc.umc_activity;
         double _mmbusy  = itr.m_busy_perc.mm_activity;
         double _temp    = itr.m_temp;
-        double _power   = gpu::is_gpu_category_mi300(_dev_id)
+        double _power   = gpu::is_current_power_supported(_dev_id)
                               ? itr.m_power.current_socket_power
                               : itr.m_power.average_socket_power;
         double _usage   = itr.m_mem_usage / static_cast<double>(units::megabyte);


### PR DESCRIPTION
# rocprofiler-systems Pull Request
 `amd-smi` has 2 different struct members used for power monitoring depending on the profiled GPU. Added a simple check in order to be able to use the correct structure for storing power consumption metrics from `amd-smi`

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [ ] Closes #<issue number>

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [x] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Please explain the changes. -->

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [x] Yes
- [ ] No - does not apply to this PR
