### PR TITLE
Upgrade binutils version from 2.42 to newer 2.44 version

### DIFF
--- a/cmake/DyninstLibIberty.cmake
+++ b/cmake/DyninstLibIberty.cmake
@@ -85,8 +85,8 @@ else()
         PREFIX ${_li_root}
         URL
             ${DYNINST_BINUTILS_DOWNLOAD_URL}
-            http://ftpmirror.gnu.org/gnu/binutils/binutils-2.42.tar.gz
-            http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.42.tar.gz
+            http://ftpmirror.gnu.org/gnu/binutils/binutils-2.44.tar.gz
+            http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.44.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3


### PR DESCRIPTION
# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- [ ] Closes #<issue number>

## What type of PR is this? (check all that apply)

- [ ] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [x] Other (please specify)

## Technical Details
- Changed  version of `bunutils` library used by `Dyninst` and `rocprofiler-systems` libraries 
in order to resolve BDBA reported vulnerability issues

## Have you added or updated tests to validate functionality?

- [ ] Yes
- [x] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [ ] No - does not apply to this PR
